### PR TITLE
PAE-94 - Add Google Tag Manager snippet to header template

### DIFF
--- a/edx-platform/pearson-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-theme/lms/templates/header/header.html
@@ -51,6 +51,10 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   </script>
 % endif
 
+% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
+    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
+% endif
+
 <header class="global-header ${'slim' if course else ''}">
     % if use_cookie_banner:
         ${static.renderReact(


### PR DESCRIPTION
This PR adds Google Tag Manager snippet in juniper migration.
Original PR: https://github.com/proversity-org/proversity-openedx-themes/pull/281