### PR TITLE
JP-1 Add variables in banner to load from settings

### DIFF
--- a/edx-platform/pearson-theme/lms/templates/index.html
+++ b/edx-platform/pearson-theme/lms/templates/index.html
@@ -15,33 +15,16 @@ quick_filters_home = configuration_helpers.get_value('quick_filters_home', [])
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="home">
-      <header>
-        <div class="outer-wrapper">
-          <div class="title">
-            <div class="heading-group">
-              % if homepage_overlay_html:
-                ${homepage_overlay_html | n, decode.utf8}
-              % else:
-                <%include file="index_overlay.html" />
-              % endif
-            </div>
-            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
-              <div class="course-search">
-                <form method="get" action="/courses">
-                  <label><span class="sr">${_("Search for a course")}</span>
-                    <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
-                  </label>
-                  <button class="search-button" type="submit">
-                    <span class="icon fa fa-search" aria-hidden="true"></span><span class="sr">${_("Search")}</span>
-                  </button>
-                </form>
-              </div>
-            % endif
+      <header class="banner ${configuration_helpers.get_value('site_title_box_class', ' ')}" style="background-image: url(${static.url(configuration_helpers.get_value('banner_image_url', 'pearson-theme/images/banner_pearson_white.jpg'))});">
+        <h1 class="title">
+          <span class="title-super">
+            ${configuration_helpers.get_value('home_page_title',' ')}
+          </span>
 
-          </div>
-
-          <%include file="index_promo_video.html" />
-        </div>
+          <p class="title-sub">
+            ${configuration_helpers.get_value('home_page_subtitle',' ')}
+          </p>
+        </h1>
 
       </header>
 


### PR DESCRIPTION
Add site_title_box_class, home_page_title, home_page_subtitle and banner_image_url variables to change banner from configuration site.
Original PR: https://github.com/proversity-org/proversity-openedx-themes/pull/102
Other commits with additional changes:
Change banner structure: https://github.com/proversity-org/proversity-openedx-themes/commit/cc285831366bd2818c1d739e6c8724d67c175cb1#diff-1c13a55869c11b93e23e823de2ce41d0R42
Add class for banner: https://github.com/proversity-org/proversity-openedx-themes/commit/373738617114fadc087d4b2207e664cf3ef92b6b
I remove the part with the comment section of the header original because it is unnecessary code 