### PR TITLE
JP-8 - Show/Hide the course number on the course template.

### DIFF
--- a/edx-platform/pearson-theme/lms/templates/course.html
+++ b/edx-platform/pearson-theme/lms/templates/course.html
@@ -17,7 +17,9 @@ from six import text_type
     <div class="course-info" aria-hidden="true">
       <h2 class="course-name">
         <span class="course-organization">${course.display_org_with_default}</span>
+        % if course.display_number_with_default != course.display_name_with_default:
         <span class="course-code">${course.display_number_with_default}</span>
+        % endif
         <span class="course-title">${course.display_name_with_default}</span>
       </h2>
       <%


### PR DESCRIPTION
## Description:

This PR changes the default behavior to show or hide the course number if the course number and code are the same.

## Previous work: 

- https://github.com/proversity-org/proversity-openedx-themes/pull/133

## Reviewers:

- [ ] @amalbas  