### PR TITLE
PE-537-bsg Hide "options" button

### DIFF
--- a/edx-platform/pearson-bsg-theme/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/dashboard/_dashboard_course_listing.html
@@ -9,6 +9,7 @@ from django.utils.translation import ungettext
 from django.urls import reverse
 from course_modes.models import CourseMode
 from course_modes.helpers import enrollment_mode_display
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import course_home_url_name
@@ -250,7 +251,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
             ## as these are the only actions currently available
             % if entitlement and (can_refund_entitlement or show_email_settings):
                 <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
-            % elif not entitlement:
+            % elif not entitlement and not configuration_helpers.get_value('HIDE_COURSE_CARD_OPTIONS', False):
                 <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
                   <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">
                     <span class="sr">${_('Course options for')}</span>


### PR DESCRIPTION
### **Description**
Use the site configuration values to hide the "options" button.
Before:
![image](https://user-images.githubusercontent.com/36944773/92530681-75442000-f1f2-11ea-8595-065d26d6b75c.png)

After:
![image](https://user-images.githubusercontent.com/36944773/92530558-3c0bb000-f1f2-11ea-97b9-8c36aac8255b.png)
### **Previous work:**
https://github.com/proversity-org/proversity-openedx-themes/pull/172