### PR TITLE
JP-9-bsg theme. Changes for the footer template.

### DIFF
--- a/edx-platform/pearson-bsg-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/footer.html
@@ -15,159 +15,72 @@ theme = configuration_helpers.get_value('theme', '')
 <% icp_license_info = getattr(settings, 'ICP_LICENSE_INFO', {})%>
 <%namespace name='static' file='static_content.html'/>
 
-% if uses_bootstrap:
-  <div class="container-fluid wrapper-footer">
-    <footer>
-      <div class="row">
-        <div class="col-md-9">
-          <nav class="navbar site-nav navbar-expand-sm" aria-label="${_('About')}">
-            <ul class="navbar-nav">
-              % for item_num, link in enumerate(footer['navigation_links'], start=1):
-                <li class="nav-item">
-                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
-                </li>
-              % endfor
-            </ul>
-          </nav>
-
-          <div class="wrapper-logo">
-            <p>
-              <a href="/">
-                ## The default logo is a placeholder.
-                ## You can either replace this link entirely or update
-                ## the FOOTER_ORGANIZATION_IMAGE in Django settings.
-                ## If you customize FOOTER_ORGANIZATION_IMAGE, then the image
-                ## can be included in the footer on other sites
-                ## (e.g. a blog or marketing front-end) to provide a consistent
-                ## user experience.  See the branding app for details.
-                <img alt="${_('organization logo')}" src="${footer['logo_image']}">
-              </a>
-            </p>
-          </div>
-
-          ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
-          <p class="copyright">${footer['copyright']}
-               % if icp_license_info.get('icp_license'):
-                ${u" | {text}".format(text=icp_license_info.get('text'))}
-                <a href="${icp_license_info.get('icp_license_link', '#')}">
-                    ${u" {icp}".format(icp=icp_license_info.get('icp_license'))}
-                </a>
-              % endif
-          </p>
-
-          <nav class="navbar legal-nav navbar-expand-sm" aria-label="${_('Legal')}">
-            <ul class="navbar-nav">
-              % for item_num, link in enumerate(footer['legal_links'], start=1):
-                <li class="nav-item">
-                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
-                </li>
-              % endfor
-              <li class="nav-item">
-                <a class="nav-link" href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a>
-              </li>
-            </ul>
-          </nav>
-        </div>
-        <div class="col-md-3">
-          ## Please leave this link and use one of the logos provided
-          ## The OpenEdX link may be hidden when this view is served
-          ## through an API to partner sites (such as marketing sites or blogs),
-          ## which are not technically powered by Open edX.
-          % if not hide_openedx_link:
-            <div class="footer-about-openedx">
-              <p>
-                <a href="${footer['openedx_link']['url']}">
-                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
-                </a>
-              </p>
-            </div>
-          % endif
-        </div>
-      </div>
-    </footer>
-  </div>
+% if theme:
+  <div class="wrapper wrapper-footer ${theme}-footer">
 % else:
-  % if theme:
-    <div class="wrapper wrapper-footer ${theme}-footer">
-  % else:
-    <div class="wrapper wrapper-footer">
-  % endif
-    <footer id="footer-openedx" class="grid-container"
-      ## When rendering the footer through the branding API,
-      ## the direction may not be set on the parent element,
-      ## so we set it here.
-      % if bidi:
-        dir=${bidi}
-      % endif
-    >
-      <div class="colophon">
-        <nav class="nav-colophon" aria-label="${_('About')}">
-          <ol>
-              % for item_num, link in enumerate(footer['navigation_links'], start=1):
-              <li class="nav-colophon-0${item_num}">
-                <a id="${link['name']}" href="${link['url']}">${link['title']}</a>
-              </li>
-              % endfor
-          </ol>
-        </nav>
-
-        % if context.get('include_language_selector', footer_language_selector_is_enabled()):
-            <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
-        % endif
-
-        <div class="wrapper-logo">
-          <p>
-            <a href="/">
-              ## The default logo is a placeholder.
-              ## You can either replace this link entirely or update
-              ## the FOOTER_ORGANIZATION_IMAGE in Django settings.
-              ## If you customize FOOTER_ORGANIZATION_IMAGE, then the image
-              ## can be included in the footer on other sites
-              ## (e.g. a blog or marketing front-end) to provide a consistent
-              ## user experience.  See the branding app for details.
-              <img alt="${_('organization logo')}" src="${footer['logo_image']}">
-            </a>
-          </p>
-        </div>
-
-        ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
-          <p class="copyright">${footer['copyright']}
-              % if icp_license_info.get('icp_license'):
-                ${u" | {text}".format(text=icp_license_info.get('text'))}
-                <a href="${icp_license_info.get('icp_license_link', '#')}">
-                    ${u" {icp}".format(icp=icp_license_info.get('icp_license'))}
-                </a>
-              % endif
-          </p>
-
-        <nav class="nav-legal" aria-label="${_('Legal')}">
-          <ul>
-            % for item_num, link in enumerate(footer['legal_links'], start=1):
-              <li class="nav-legal-0${item_num}">
-                <a href="${link['url']}">${link['title']}</a>
-              </li>
-            % endfor
-            <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
-          </ul>
-        </nav>
-      </div>
-
-      ## Please leave this link and use one of the logos provided
-      ## The OpenEdX link may be hidden when this view is served
-      ## through an API to partner sites (such as marketing sites or blogs),
-      ## which are not technically powered by OpenEdX.
-      % if not hide_openedx_link:
-      <div class="footer-about-openedx">
-        <p>
-          <a href="${footer['openedx_link']['url']}">
-            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
-          </a>
-        </p>
-      </div>
-      % endif
-    </footer>
-  </div>
+  <div class="wrapper wrapper-footer">
 % endif
+  <footer id="footer-openedx" class="grid-container"
+  ## When rendering the footer through the branding API,
+  ## the direction may not be set on the parent element,
+  ## so we set it here.
+  % if bidi:
+    dir=${bidi}
+  % endif
+  >
+    <div class="colophon">
+      <nav class="nav-colophon" aria-label="${_('About')}">
+        <ol>
+          % for item_num, link in enumerate(footer['navigation_links'], start=1):
+          <li class="nav-colophon-0${item_num}">
+            <a id="${link['name']}" href="${link['url']}">${link['title']}</a>
+          </li>
+          % endfor
+        </ol>
+      </nav>
+
+      % if context.get('include_language_selector', footer_language_selector_is_enabled()):
+      <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
+      % endif
+
+      <nav class="nav-legal" aria-label="${_('Legal')}">
+        <ul>
+          % for item_num, link in enumerate(footer['legal_links'], start=1):
+            % if link['name'] == 'honor_code':
+              <% continue %>
+            % endif
+            <li class="nav-legal-0${item_num}">
+              <a href="${link['url']}">${link['title']}</a>
+            </li>
+          % endfor
+          <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
+        </ul>
+      </nav>
+    </div>
+
+    ## Please leave this link and use one of the logos provided
+    ## The OpenEdX link may be hidden when this view is served
+    ## through an API to partner sites (such as marketing sites or blogs),
+    ## which are not technically powered by OpenEdX.
+    % if not hide_openedx_link:
+    <div class="footer-about-openedx">
+      ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      <p class="copyright">${footer['copyright']}
+        % if icp_license_info.get('icp_license'):
+        ${u" | {text}".format(text=icp_license_info.get('text'))}
+        <a href="${icp_license_info.get('icp_license_link', '#')}">
+          ${u" {icp}".format(icp=icp_license_info.get('icp_license'))}
+        </a>
+        % endif
+      </p>
+      <a href="${footer['openedx_link']['url']}">
+        <img src="/static/pearson-pols-theme/images/openedx.svg" alt="Powered by Open edX" width="150" />
+      </a>
+    </div>
+    % endif
+  </footer>
+</div>
+
 % if include_dependencies:
   <%static:js group='base_vendor'/>
   <%static:css group='style-vendor'/>


### PR DESCRIPTION
### **Description**
-Removes the bootstrap footer block.
-Removes the footer logo image.
-Skip honor code page link.
-Changes the open edX logo image
-Change copyright text position.
Before:
![footer-before](https://user-images.githubusercontent.com/36944773/92813569-0fd56800-f387-11ea-8815-aedb1b816bad.jpg)

After:
![image](https://user-images.githubusercontent.com/36944773/92813469-d270da80-f386-11ea-85cb-c890ebb2acd3.png)

### **Previous Work**
proversity-org/proversity-openedx-themes#241
Commits:
proversity-org/proversity-openedx-themes@3d0b862
proversity-org/proversity-openedx-themes@294e935