### PR TITLE
Make the LMS_ROOT_URL setting site aware

### DIFF
--- a/edx-platform/pearson-pols-theme/lms/templates/header/navbar-logo-header.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/header/navbar-logo-header.html
@@ -14,7 +14,7 @@ from branding import api as branding_api
 %>
 
 <h1 class="header-logo">
-  <a href="${branding_api.get_home_url()}">
+  <a href="${configuration_helpers.get_value('LMS_ROOT_URL', branding_api.get_home_url())}">
     <%block name="navigation_logo">
     <img  class="logo" src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
     </%block>


### PR DESCRIPTION
### **Description:**
Make the LMS_ROOT_URL setting site aware in the navbar-logo-header template.

### **Previous work:**
https://github.com/proversity-org/proversity-openedx-themes/pull/136