### PR TITLE
JP-1-pols Add variables in banner to load from settings

### DIFF
--- a/edx-platform/pearson-pols-theme/lms/templates/index.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/index.html
@@ -11,35 +11,20 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="home">
-      <header>
-        <div class="outer-wrapper">
-          <div class="title ${configuration_helpers.get_value('theme', '')}">
-            <div class="heading-group">
-              % if homepage_overlay_html:
-                ${homepage_overlay_html | n, decode.utf8}
-              % else:
-                <%include file="index_overlay.html" />
-              % endif
-            </div>
-            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
-              <div class="course-search">
-                <form method="get" action="/courses">
-                  <label><span class="sr">${_("Search for a course")}</span>
-                    <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
-                  </label>
-                  <button class="search-button" type="submit">
-                    <span class="icon fa fa-search" aria-hidden="true"></span><span class="sr">${_("Search")}</span>
-                  </button>
-                </form>
-              </div>
-            % endif
+      <section class="home-banner">
+          <header class="banner ${configuration_helpers.get_value('site_title_box_class', ' ')}" >
 
-          </div>
-
-          <%include file="index_promo_video.html" />
-        </div>
-
-      </header>
+          <img style="width:100%" src="${static.url(configuration_helpers.get_value('banner_image_url', '/static/pearson-pols-theme/images/banner-pols.jpg'))}" />
+            </header>
+             <h1 class="title configuration_helpers.get_value('theme', '')">
+                <span class="title-super">
+                  ${configuration_helpers.get_value('home_page_title', 'Welcome')}
+                </span>
+                <p class="title-sub">
+                  ${configuration_helpers.get_value('home_page_subtitle', 'We think you might be interested in these programs')}
+                </p>
+             </h1>
+        </section>
       <%include file="${courses_list}" />
 
     </section>


### PR DESCRIPTION
### **Description**
Add home_page_title, home_page_subtitle and banner_image_url variables. Fix styles
**Before:**
![image](https://user-images.githubusercontent.com/36944773/93950001-d518eb80-fd07-11ea-88ef-7c40ac96afe3.png)

**After:**
![image](https://user-images.githubusercontent.com/36944773/93949987-c5010c00-fd07-11ea-9e73-8f9d23ae31fa.png)

### **Previous work**
proversity-org/proversity-openedx-themes#102
proversity-org/proversity-openedx-themes@4844e05