### PR TITLE
JP-7- pols Add hide_edx_login setting to show or hide the login and register forms

### DIFF
--- a/edx-platform/pearson-pols-theme/lms/templates/student_account/login_and_register.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/student_account/login_and_register.html
@@ -29,6 +29,26 @@
     % endif
 </%block>
 
+% if configuration_helpers.get_value('hide_edx_login', False):
+    <style>
+    #login-form .toggle-form,
+    #login-form .form-field,
+    #login-form .login-button,
+    #login-form .login-providers .section-title,
+    #register-form .login-providers .section-title,
+    #register-form .toggle-form,
+    #register-form .required-fields,
+    #register-form .form-field,
+    #register-form .register-button {
+        display: none;
+    }
+
+    #login-form h2, #register-form h2 {
+        text-align: center;
+    }
+    </style>
+% endif
+
 <%block name="header_extras">
     % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
         <script type="text/template" id="${template_name}-tpl">


### PR DESCRIPTION
### **Description:**
Add the hide_edx_login setting to show or hide the login and register forms on the login_and_register template.

**Before:**
![image](https://user-images.githubusercontent.com/36944773/94169651-abb9a600-fe54-11ea-9580-8ab2b798774e.png)

**After:**
![image](https://user-images.githubusercontent.com/36944773/94169571-993f6c80-fe54-11ea-90ac-1f05672b647e.png)
### **Previous work:**
https://github.com/proversity-org/proversity-openedx-themes/pull/221