### PR TITLE
JP-9 learninghub Changes for the footer template 

### DIFF
--- a/edx-platform/pearson-learninghub-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/footer.html
@@ -15,159 +15,67 @@ theme = configuration_helpers.get_value('theme', '')
 <% icp_license_info = getattr(settings, 'ICP_LICENSE_INFO', {})%>
 <%namespace name='static' file='static_content.html'/>
 
-% if uses_bootstrap:
-  <div class="container-fluid wrapper-footer">
-    <footer>
-      <div class="row">
-        <div class="col-md-9">
-          <nav class="navbar site-nav navbar-expand-sm" aria-label="${_('About')}">
-            <ul class="navbar-nav">
-              % for item_num, link in enumerate(footer['navigation_links'], start=1):
-                <li class="nav-item">
-                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
-                </li>
-              % endfor
-            </ul>
-          </nav>
-
-          <div class="wrapper-logo">
-            <p>
-              <a href="/">
-                ## The default logo is a placeholder.
-                ## You can either replace this link entirely or update
-                ## the FOOTER_ORGANIZATION_IMAGE in Django settings.
-                ## If you customize FOOTER_ORGANIZATION_IMAGE, then the image
-                ## can be included in the footer on other sites
-                ## (e.g. a blog or marketing front-end) to provide a consistent
-                ## user experience.  See the branding app for details.
-                <img alt="${_('organization logo')}" src="${footer['logo_image']}">
-              </a>
-            </p>
-          </div>
-
-          ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
-          <p class="copyright">${footer['copyright']}
-               % if icp_license_info.get('icp_license'):
-                ${u" | {text}".format(text=icp_license_info.get('text'))}
-                <a href="${icp_license_info.get('icp_license_link', '#')}">
-                    ${u" {icp}".format(icp=icp_license_info.get('icp_license'))}
-                </a>
-              % endif
-          </p>
-
-          <nav class="navbar legal-nav navbar-expand-sm" aria-label="${_('Legal')}">
-            <ul class="navbar-nav">
-              % for item_num, link in enumerate(footer['legal_links'], start=1):
-                <li class="nav-item">
-                  <a class="nav-link" href="${link['url']}">${link['title']}</a>
-                </li>
-              % endfor
-              <li class="nav-item">
-                <a class="nav-link" href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a>
-              </li>
-            </ul>
-          </nav>
-        </div>
-        <div class="col-md-3">
-          ## Please leave this link and use one of the logos provided
-          ## The OpenEdX link may be hidden when this view is served
-          ## through an API to partner sites (such as marketing sites or blogs),
-          ## which are not technically powered by Open edX.
-          % if not hide_openedx_link:
-            <div class="footer-about-openedx">
-              <p>
-                <a href="${footer['openedx_link']['url']}">
-                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
-                </a>
-              </p>
-            </div>
-          % endif
-        </div>
-      </div>
-    </footer>
-  </div>
-% else:
-  % if theme:
-    <div class="wrapper wrapper-footer ${theme}-footer">
-  % else:
-    <div class="wrapper wrapper-footer">
+<div class="wrapper wrapper-footer">
+  <footer id="footer-openedx" class="grid-container"
+  ## When rendering the footer through the branding API,
+  ## the direction may not be set on the parent element,
+  ## so we set it here.
+  % if bidi:
+  dir=${bidi}
   % endif
-    <footer id="footer-openedx" class="grid-container"
-      ## When rendering the footer through the branding API,
-      ## the direction may not be set on the parent element,
-      ## so we set it here.
-      % if bidi:
-        dir=${bidi}
-      % endif
-    >
-      <div class="colophon">
-        <nav class="nav-colophon" aria-label="${_('About')}">
-          <ol>
-              % for item_num, link in enumerate(footer['navigation_links'], start=1):
-              <li class="nav-colophon-0${item_num}">
-                <a id="${link['name']}" href="${link['url']}">${link['title']}</a>
-              </li>
-              % endfor
-          </ol>
-        </nav>
+  >
+    <div class="colophon">
+      <nav class="nav-colophon" aria-label="${_('About')}">
+        <ol>
+          % for item_num, link in enumerate(footer['navigation_links'], start=1):
+            <li class="nav-colophon-0${item_num}">
+              <a id="${link['name']}" href="${link['url']}">${link['title']}</a>
+            </li>
+          % endfor
+        </ol>
+      </nav>
 
-        % if context.get('include_language_selector', footer_language_selector_is_enabled()):
-            <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
+      % if context.get('include_language_selector', footer_language_selector_is_enabled()):
+      <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
+      % endif
+
+      <nav class="nav-legal" aria-label="${_('Legal')}">
+        <ul>
+          % for item_num, link in enumerate(footer['legal_links'], start=1):
+            % if link['name'] == 'honor_code':
+              <% continue %>
+            % endif
+            <li class="nav-legal-0${item_num}">
+              <a href="${link['url']}">${link['title']}</a>
+            </li>
+          % endfor
+          <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
+        </ul>
+      </nav>
+    </div>
+
+    ## Please leave this link and use one of the logos provided
+    ## The OpenEdX link may be hidden when this view is served
+    ## through an API to partner sites (such as marketing sites or blogs),
+    ## which are not technically powered by OpenEdX.
+    % if not hide_openedx_link:
+    <div class="footer-about-openedx">
+      ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+      <p class="copyright">${footer['copyright']}
+        % if icp_license_info.get('icp_license'):
+        ${u" | {text}".format(text=icp_license_info.get('text'))}
+        <a href="${icp_license_info.get('icp_license_link', '#')}">
+        ${u" {icp}".format(icp=icp_license_info.get('icp_license'))}
+        </a>
         % endif
-
-        <div class="wrapper-logo">
-          <p>
-            <a href="/">
-              ## The default logo is a placeholder.
-              ## You can either replace this link entirely or update
-              ## the FOOTER_ORGANIZATION_IMAGE in Django settings.
-              ## If you customize FOOTER_ORGANIZATION_IMAGE, then the image
-              ## can be included in the footer on other sites
-              ## (e.g. a blog or marketing front-end) to provide a consistent
-              ## user experience.  See the branding app for details.
-              <img alt="${_('organization logo')}" src="${footer['logo_image']}">
-            </a>
-          </p>
-        </div>
-
-        ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
-          <p class="copyright">${footer['copyright']}
-              % if icp_license_info.get('icp_license'):
-                ${u" | {text}".format(text=icp_license_info.get('text'))}
-                <a href="${icp_license_info.get('icp_license_link', '#')}">
-                    ${u" {icp}".format(icp=icp_license_info.get('icp_license'))}
-                </a>
-              % endif
-          </p>
-
-        <nav class="nav-legal" aria-label="${_('Legal')}">
-          <ul>
-            % for item_num, link in enumerate(footer['legal_links'], start=1):
-              <li class="nav-legal-0${item_num}">
-                <a href="${link['url']}">${link['title']}</a>
-              </li>
-            % endfor
-            <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
-          </ul>
-        </nav>
-      </div>
-
-      ## Please leave this link and use one of the logos provided
-      ## The OpenEdX link may be hidden when this view is served
-      ## through an API to partner sites (such as marketing sites or blogs),
-      ## which are not technically powered by OpenEdX.
-      % if not hide_openedx_link:
-      <div class="footer-about-openedx">
-        <p>
-          <a href="${footer['openedx_link']['url']}">
-            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
-          </a>
-        </p>
-      </div>
-      % endif
-    </footer>
-  </div>
-% endif
+      </p>
+      <a href="${footer['openedx_link']['url']}">
+        <img src="/static/pearson-pols-theme/images/openedx.svg" alt="Powered by Open edX" width="150" />
+      </a>
+    </div>
+    % endif
+  </footer>
+</div>
 % if include_dependencies:
   <%static:js group='base_vendor'/>
   <%static:css group='style-vendor'/>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/footer.html
@@ -15,7 +15,11 @@ theme = configuration_helpers.get_value('theme', '')
 <% icp_license_info = getattr(settings, 'ICP_LICENSE_INFO', {})%>
 <%namespace name='static' file='static_content.html'/>
 
-<div class="wrapper wrapper-footer">
+% if theme:
+  <div class="wrapper wrapper-footer ${theme}-footer">
+% else:
+  <div class="wrapper wrapper-footer">
+% endif
   <footer id="footer-openedx" class="grid-container"
   ## When rendering the footer through the branding API,
   ## the direction may not be set on the parent element,

--- a/edx-platform/pearson-learninghub-theme/lms/templates/widgets/footer-language-selector.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/widgets/footer-language-selector.html
@@ -1,0 +1,83 @@
+## Language-selection widget for the footer.
+##
+## Requires settings.LANGUAGE_COOKIE.
+<%page expression_filter="h"/>
+<%!
+  from babel import Locale
+  from django.conf import settings
+  from django.utils.translation import ugettext as _
+
+  from openedx.core.djangoapps.lang_pref import COOKIE_DURATION
+  from openedx.core.djangoapps.lang_pref.api import released_languages
+  from openedx.core.djangolib.js_utils import js_escaped_string
+
+  # Make sure LANGUAGE_COOKIE is present.
+  if not settings.LANGUAGE_COOKIE:
+      raise ValueError('settings.LANGUAGE_COOKIE is required to use footer-language-selector.')
+%>
+<%namespace name='static' file='../static_content.html'/>
+
+<div class="footer-language-selector">
+    <div role="group" aria-label="Change page language">
+        <label for="footer-language-select">
+            <span class="icon fa fa-globe" aria-hidden="true"></span>
+            <span class="sr">${_("Choose Language")}</span>
+        </label>
+        <select id="footer-language-select" name="language">
+            % for language in sorted(released_languages(), key=lambda x: x.code):
+                <% language_name = Locale.parse(language.code.replace('_', '-'), sep='-').language_name %>
+                % if language.code == LANGUAGE_CODE:
+                    <option value="${language.code}" selected="selected">${language_name}</option>
+                % else:
+                    <option value="${language.code}">${language_name}</option>
+                % endif
+            % endfor
+        </select>
+        <button id="footer-language-button" type="button" class="btn-edged-blue select-lang-button"
+                onclick="footerLanguageSelector.langSelection()">
+            ${_('Submit')}
+        </button>
+    </div>
+</div>
+
+<script type="text/javascript">
+    window.footerLanguageSelector = {
+        ##
+        ## Set the language cookie using the same settings as
+        ## https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/lang_pref/views.py#L26
+        ## and
+        ## https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/lang_pref/middleware.py#63
+        ## Then refresh the page so that the language negotiation middleware can read it and re-render everything
+        ## in the selected language.
+        ##
+        ## NOTE: For logged-in users, the LMS language negotiation middleware should persist the selected language
+        ## preference to the user's profile. This effect may be delayed on pages that do not use the LMS language
+        ## selection middleware.
+        ##
+        langSelection: function() {
+            var footer = document.getElementById('footer-language-select');
+            var lang = footer.options[footer.selectedIndex].value;
+            this.setLanguageCookie(lang, this.refreshPage);
+        },
+
+        setLanguageCookie: function(value, callback) {
+            var cookie = '${settings.LANGUAGE_COOKIE | n, js_escaped_string}=' + value + ';path=/';
+
+            <% session_cookie_domain = static.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN) %>
+            % if session_cookie_domain:
+                cookie += ';domain=${session_cookie_domain | n, js_escaped_string}';
+            % endif
+            % if COOKIE_DURATION:
+                cookie += ';max-age=${COOKIE_DURATION | n, js_escaped_string}';
+            % endif
+
+            document.cookie = cookie;
+
+            callback();
+        },
+
+        refreshPage: function() {
+            window.location.reload();
+        }
+    };
+</script>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/widgets/footer-language-selector.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/widgets/footer-language-selector.html
@@ -18,26 +18,20 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <div class="footer-language-selector">
-    <div role="group" aria-label="Change page language">
-        <label for="footer-language-select">
-            <span class="icon fa fa-globe" aria-hidden="true"></span>
-            <span class="sr">${_("Choose Language")}</span>
-        </label>
-        <select id="footer-language-select" name="language">
-            % for language in sorted(released_languages(), key=lambda x: x.code):
-                <% language_name = Locale.parse(language.code.replace('_', '-'), sep='-').language_name %>
-                % if language.code == LANGUAGE_CODE:
-                    <option value="${language.code}" selected="selected">${language_name}</option>
-                % else:
-                    <option value="${language.code}">${language_name}</option>
-                % endif
-            % endfor
-        </select>
-        <button id="footer-language-button" type="button" class="btn-edged-blue select-lang-button"
-                onclick="footerLanguageSelector.langSelection()">
-            ${_('Submit')}
-        </button>
-    </div>
+    <label for="footer-language-select">
+        <span class="icon fa fa-globe" aria-hidden="true"></span>
+        <span class="sr">${_("Choose Language")}</span>
+    </label>
+    <select id="footer-language-select" name="language" onchange="footerLanguageSelector.handleSelection(this)">
+        % for language in sorted(released_languages(), key=lambda x: x.code):
+            <% language_name = Locale.parse(language.code.replace('_', '-'), sep='-').language_name %>
+            % if language.code == LANGUAGE_CODE:
+                <option value="${language.code}" selected="selected">${language_name}</option>
+            % else:
+                <option value="${language.code}">${language_name}</option>
+            % endif
+        % endfor
+    </select>
 </div>
 
 <script type="text/javascript">
@@ -54,10 +48,8 @@
         ## preference to the user's profile. This effect may be delayed on pages that do not use the LMS language
         ## selection middleware.
         ##
-        langSelection: function() {
-            var footer = document.getElementById('footer-language-select');
-            var lang = footer.options[footer.selectedIndex].value;
-            this.setLanguageCookie(lang, this.refreshPage);
+        handleSelection: function($select) {
+            this.setLanguageCookie($select.value, this.refreshPage);
         },
 
         setLanguageCookie: function(value, callback) {


### PR DESCRIPTION
Description
-Removes the bootstrap footer block.
-Removes the footer logo image.
-Skip honor code page link.
-Changes the open edX logo image
-Change copyright text position.
-Change footer language template
Before:
![image](https://user-images.githubusercontent.com/36944773/94468662-682fa680-018a-11eb-98e8-9dc210a29c2e.png)

After:
![image](https://user-images.githubusercontent.com/36944773/94468497-1edf5700-018a-11eb-8443-242f333a03cf.png)

Previous Work
proversity-org/proversity-openedx-themes#241
Commits:
proversity-org/proversity-openedx-themes@3d0b862
proversity-org/proversity-openedx-themes@294e935