### PR TITLE
PE-786-learninghub Changes on dropdown and header template.

### DIFF
--- a/edx-platform/pearson-learninghub-theme/lms/templates/header/navbar-authenticated.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/header/navbar-authenticated.html
@@ -15,6 +15,8 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   show_sysadmin_dashboard = settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff
   self.real_user = getattr(user, 'real_user', user)
   show_catalogue_link = configuration_helpers.get_value('show_catalogue_link', show_explore_courses)
+  show_profile_in_dropdown = configuration_helpers.get_value('SHOW_PROFILE_IN_DROPDOWN', False)
+  show_dashboard_in_dropdown = configuration_helpers.get_value('SHOW_DASHBOARD_IN_DROPDOWN', False)
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
@@ -30,18 +32,28 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 <div class="nav-links">
   <div class="main">
     % if show_dashboard_tabs:
-      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
-             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
-             ${_("Courses")}
-        </a>
-      </div>
+      % if not show_dashboard_in_dropdown:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+               aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+               ${_("Courses")}
+          </a>
+        </div>
+      % endif
       % if show_program_listing:
         <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
           <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
              aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
              ${_("Programs")}
           </a>
+        </div>
+      % endif
+      % if not show_profile_in_dropdown:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+            <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}"
+               aria-current="${'page' if '/u/' in request.path else 'false'}">
+               ${_("Profile")}
+            </a>
         </div>
       % endif
     % endif

--- a/edx-platform/pearson-learninghub-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/header/user_dropdown.html
@@ -11,6 +11,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
 from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <%
@@ -37,11 +38,22 @@ displayname = get_enterprise_learner_generic_name(request) or username
         % if resume_block:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
+        % if configuration_helpers.get_value('SHOW_DASHBOARD_IN_DROPDOWN', False):
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item">
+                <a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a>
+            </div>
+        % endif
+        % if configuration_helpers.get_value('SHOW_PROFILE_IN_DROPDOWN', False):
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item">
+                <a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a>
+            </div>
+        % endif
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
         % if should_redirect_to_order_history_microfrontend():
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
+        % endif
+        % if configuration_helpers.get_value('EXTERNAL_SUPPORT_LINK', ''):
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${configuration_helpers.get_value('EXTERNAL_SUPPORT_LINK')}">${_("Support")}</a></div>
         % endif
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
     </div>


### PR DESCRIPTION
### **Description**
Add changes on header pearson:

- Show dashboard and profile link next to the logo and not in the dropdown menu.
- Show 'support' link in dropdown menu when variable EXTERNAL_SUPPORT_LINK is used.

**Before:**
![image](https://user-images.githubusercontent.com/36944773/94481703-c44ff600-019d-11eb-92ad-f4c4963facf1.png)

**After:**
![image](https://user-images.githubusercontent.com/36944773/94481635-a71b2780-019d-11eb-9ecb-f1a981f65b9f.png)

### **Previous work:**
proversity-org/proversity-openedx-themes#245