### PR TITLE
PE-685-learninghub Add variable to show/hide explore button on profile.

### DIFF
--- a/edx-platform/pearson-learninghub-theme/lms/templates/learner_profile/learner-achievements-fragment.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/learner_profile/learner-achievements-fragment.html
@@ -6,6 +6,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
@@ -71,7 +72,7 @@ from openedx.core.djangolib.markup import HTML, Text
         % elif own_profile:
             <div class="learner-message">
                 <h4 class="message-header">${_("You haven't earned any certificates yet.")}</h4>
-                % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+                % if configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE')):
                     <p class="message-actions">
                         <a class="btn btn-brand" href="${marketing_link('COURSES')}">
                             <span class="icon fa fa-search" aria-hidden="true"></span>


### PR DESCRIPTION
### **Description**
Add the COURSES_ARE_BROWSABLE as a site aware variable to remove course explore button.

**Show:**
![image](https://user-images.githubusercontent.com/36944773/94486429-0b8db500-01a5-11eb-8ec9-cf18810d14bf.png)

**Hide:**
![image](https://user-images.githubusercontent.com/36944773/94486364-f022aa00-01a4-11eb-96fa-9e3e49767cf7.png)

### **Previous work**
proversity-org/proversity-openedx-themes#228
EXPLORE_COURSES_ON_PROFILE was replaced by  COURSES_ARE_BROWSABLE