### PR TITLE
PE-665 - Hide ccx master course from dashboard.

### DIFF
--- a/edx-platform/pearson-learninghub-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/dashboard.html
@@ -157,9 +157,26 @@ from student.models import CourseEnrollment
             'SOCIAL_SHARING_SETTINGS',
             getattr(settings, 'SOCIAL_SHARING_SETTINGS', {})
           )
+          show_ccx_master_courses = user.profile.get_meta().get('show_ccx_master_courses', 'hide')
+          ccx_courses = user.customcourseforedx_set.filter(coach_id=user.id) if show_ccx_master_courses == 'hide' else []
         %>
         % for dashboard_index, enrollment in enumerate(course_entitlements + course_enrollments):
         <div class="items course single-course">
+          <%
+            is_master_course = False
+          %>
+
+          % if not getattr(enrollment.course_id, 'ccx', None):
+            % for ccx_course in ccx_courses:
+              <%
+                is_master_course = enrollment.course_id == ccx_course.course_id
+              %>
+            % endfor
+          %endif
+
+          % if is_master_course:
+            <% continue %>
+          % endif
         <%
           # Check if the course run is an entitlement and if it has an associated session
           entitlement = enrollment if isinstance(enrollment, CourseEntitlement) else None


### PR DESCRIPTION
### **Description:**
This PR adds the option to hide the CCX master course from the dashboard to the coach users.
It checks for the extended profile field called show_ccx_master_courses to show or hide the master courses; by default it will hide the CCX master courses.
### **Previous work:**
https://github.com/proversity-org/proversity-openedx-themes/pull/235