### PR TITLE
PAE-328 - Check for an empty setting value to hide the CCX main courses.

### DIFF
--- a/edx-platform/pearson-learninghub-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/dashboard.html
@@ -158,7 +158,10 @@ from student.models import CourseEnrollment
             getattr(settings, 'SOCIAL_SHARING_SETTINGS', {})
           )
           show_ccx_master_courses = user.profile.get_meta().get('show_ccx_master_courses', 'hide')
-          ccx_courses = user.customcourseforedx_set.filter(coach_id=user.id) if show_ccx_master_courses == 'hide' else []
+          ccx_courses = []
+
+          if not show_ccx_master_courses or show_ccx_master_courses == 'hide':
+            ccx_courses = user.customcourseforedx_set.filter(coach_id=user.id)
         %>
         % for dashboard_index, enrollment in enumerate(course_entitlements + course_enrollments):
         <div class="items course single-course">


### PR DESCRIPTION
## Background:

A custom setting defined in the extended profile fields called: show_ccx_master_courses is in charge of hiding or showing main CCX courses on the coach dashboard. The default behaviour for users who do not modify this setting in the Account Settings page should be to hide the main CCX courses, but this does not happen, when a new user signs up, the sign-up process will set an empty value for this custom setting in the Profile metadata model and the feature only check for a specific value instead of both empty and specific values.

## Description:

This PR fixes a bug where CCX main courses were not hidden even if the custom setting value in the Profile metadata was empty.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luis4