### PR TITLE
PAE-524 - Not authenticated navbar configurable

### DIFF
--- a/edx-platform/pearson-theme/lms/templates/header/navbar-not-authenticated.html
+++ b/edx-platform/pearson-theme/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = static.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE', False))
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  how_it_works_link_enable = static.get_value('HOW_IT_WORKS_LINK_ENABLE', settings.FEATURES.get('HOW_IT_WORKS_LINK_ENABLE', False))
+  schools_link_enable = static.get_value('SCHOOLS_LINK_ENABLE', settings.FEATURES.get('SCHOOLS_LINK_ENABLE', False))
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if mktg_site_enabled:
+    % if how_it_works_link_enable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+      </div>
+    % endif
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    % if schools_link_enable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+      </div>
+    % endif
+  % endif
+  % if allows_login:
+    % if can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+        % endif
+          <div class="mobile-nav-item hidden-mobile nav-item">
+            <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+      % endif
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
Description
---------------
Allows you to hide and show the marketing site links in the navigation bar when you are not authenticated, can be configured in lms.env.json or in per site configuration. This configuration uses the following flags:

- COURSES_ARE_BROWSABLE
- HOW_IT_WORKS_LINK_ENABLE
- SCHOOLS_LINK_ENABLE


**Ticket:** [PAE-524](https://pearsonadvance.atlassian.net/browse/PAE-524)