### PR TITLE
PAE-576.2 - Use of !important in header links

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_header.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_header.scss
@@ -96,7 +96,7 @@
 
       .main {
         @include float(left);
-        @include margin($baseline*0.9, 0, 0, $baseline);
+        margin: $baseline*0.9 0 0 $baseline !important;
 
         .nav-item {
           @include float(left);


### PR DESCRIPTION
Description
---------------
The profile page uses the platform's css, so that this does not happen I have used !important so that it has the theme as priority.