### PR TITLE
PAE-577.2 - Add the rule !important to the underline of the header tab

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_header.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_header.scss
@@ -110,7 +110,7 @@
 
           a {
             color: theme-color("secondary");
-            padding: $baseline*0.35 $baseline*1.25 15px;
+            padding: $baseline*0.35 $baseline*1.25 15px !important;
             font-weight: $font-weight-normal;
             display: inline-block;
             margin-bottom: -1*$baseline/2;


### PR DESCRIPTION
Description
---------------
In the profile page the platform CSS takes priority, so I have added the important to solve this.

**Before:**
![image](https://user-images.githubusercontent.com/10764344/107800469-cd94c600-6d2c-11eb-8871-051c3737852f.png)

**After:**
![image](https://user-images.githubusercontent.com/10764344/107800617-fae17400-6d2c-11eb-8883-b630bc61152f.png)
