### PR TITLE
Update course image size in dashboard

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_dashboard.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_dashboard.scss
@@ -1,0 +1,7 @@
+.dashboard .main-container .my-courses .course .details .wrapper-course-image {
+  float: left;
+  margin-right: 2.35765%;
+  width: 23.23176%;
+  max-height: 160px;
+  overflow: hidden;
+}

--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -11,6 +11,7 @@
 @import 'navigation';
 @import 'footer';
 @import 'course-experience';
+@import 'dashboard';
 
 
 //registration


### PR DESCRIPTION
Description
---------------
update the height of the course image for the pearson-vue-theme. This fix creates an upgrade for 1980x1024 screens, in full screen mode the image looks full.

Screenshots
-----------------

**Before:**
![image](https://user-images.githubusercontent.com/10764344/109079699-4dc40f80-76cd-11eb-93be-c4ab22c3d101.png)

**After:**
![image](https://user-images.githubusercontent.com/10764344/109079641-384ee580-76cd-11eb-8b2d-d583c149dc4a.png)


**Note:** pearson-vue-theme should use 280x160 images for better visualization.