### PR TITLE
PAE-636 - Remove the broken support email link.

### DIFF
--- a/edx-platform/pearson-bsg-theme/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/edx-platform/pearson-bsg-theme/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -49,27 +49,6 @@
             </div>
         </td>
     </tr>
-  <!--  <tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr> --> 
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -58,18 +58,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -57,19 +57,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
-    <tr>
-        <td>
             <p>
                 {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -83,18 +83,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-            color: #505759;
-            text-align: left;
-            padding: 2% 5%;
-            margin: 0px;">
-            {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-            <br />
-        </p>
-    </td>
-    <tr>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
@@ -37,20 +37,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -37,20 +37,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -59,20 +59,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -38,20 +38,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-bsg-theme/lms/templates/student/edx_ace/accountactivation/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/student/edx_ace/accountactivation/email/body.html
@@ -54,19 +54,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
-    <tr>
-        <td>
             <p>
                 {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-bsg-theme/lms/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/student/edx_ace/accountrecovery/email/body.html
@@ -44,20 +44,5 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-
-</tr>
-
 </table>
 {% endblock %}

--- a/edx-platform/pearson-bsg-theme/lms/templates/student/edx_ace/emailchange/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/student/edx_ace/emailchange/email/body.html
@@ -46,19 +46,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
-    <tr>
-        <td>
             <p>
                  {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ site_name }} web site.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-bsg-theme/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
+++ b/edx-platform/pearson-bsg-theme/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
@@ -63,19 +63,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
-
 </table>
 {% endblock %}

--- a/edx-platform/pearson-learninghub-theme/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -49,27 +49,6 @@
             </div>
         </td>
     </tr>
-  <!--  <tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr> --> 
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -55,18 +55,5 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -56,19 +56,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -99,19 +99,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-            color: #505759;
-            text-align: left;
-            padding: 2% 5%;
-            margin: 0px;">
-            {% filter force_escape %}
-            {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-            {% endfilter %}
-            <br />
-            </p>
-        </td>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
@@ -36,20 +36,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -37,19 +37,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -53,19 +53,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -36,19 +36,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/student/edx_ace/accountactivation/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/student/edx_ace/accountactivation/email/body.html
@@ -49,20 +49,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/student/edx_ace/accountrecovery/email/body.html
@@ -42,17 +42,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-learninghub-theme/lms/templates/student/edx_ace/emailchange/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/student/edx_ace/emailchange/email/body.html
@@ -46,18 +46,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>
             <p>
                  {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ site_name }} web site.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-learninghub-theme/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
@@ -62,17 +62,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-pols-theme/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/edx-platform/pearson-pols-theme/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -49,27 +49,6 @@
             </div>
         </td>
     </tr>
-  <!--  <tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr> --> 
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -56,17 +56,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -54,18 +54,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>
             <p>
                 {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -99,19 +99,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-            color: #505759;
-            text-align: left;
-            padding: 2% 5%;
-            margin: 0px;">
-            {% filter force_escape %}
-            {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-            {% endfilter %}
-            <br />
-            </p>
-        </td>
-    </tr>
 </table>
 {% endblock %}

--- a/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -37,20 +37,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    <tr>
-     </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -59,19 +59,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -38,19 +38,6 @@
             </div>
         </td>
     </tr>
-
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
     <tr>
         <td>
             <p>

--- a/edx-platform/pearson-pols-theme/lms/templates/student/edx_ace/accountactivation/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/student/edx_ace/accountactivation/email/body.html
@@ -54,18 +54,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>
             <p>
                 {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-pols-theme/lms/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/student/edx_ace/accountrecovery/email/body.html
@@ -43,18 +43,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
-
 </table>
 {% endblock %}

--- a/edx-platform/pearson-pols-theme/lms/templates/student/edx_ace/emailchange/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/student/edx_ace/emailchange/email/body.html
@@ -46,18 +46,6 @@
     </tr>
     <tr>
         <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>
             <p>
                  {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ site_name }} web site.{% endblocktrans %}
                 <br />

--- a/edx-platform/pearson-pols-theme/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
@@ -63,18 +63,5 @@
             </div>
         </td>
     </tr>
-    <tr>
-        <td>
-            <p style="font-family: 'Open Sans', sans-serif;
-                color: #505759;
-                text-align: left;
-                padding: 2% 5%;
-                margin: 0px;">
-                {% blocktrans %}If you are receiving this email in error, please let us know at <a href="mailto:{{ support_email }}">{{ support_email }}</a>.{% endblocktrans %}
-                <br />
-            </p>
-        </td>
-    </tr>
-
 </table>
 {% endblock %}


### PR DESCRIPTION
## Description:

This PR removes the support email link from some email templates because the link is not available.

## Reviewers:

- [ ] @luismorenolopera 
- [ ] @ivanvgh 