### PR TITLE
PAE-660.2 - Show or hide login and registration buttons with site configuration

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/header/navbar-not-authenticated.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/navbar-not-authenticated.html
@@ -15,7 +15,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 <%
   mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
   course_link_enable = static.get_value('COURSE_LINK_ENABLE', settings.FEATURES.get('COURSE_LINK_ENABLE', False))
-  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  allows_login = not configuration_helpers.get_value('DISABLE_LOGIN_BUTTON', False)
   can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
   allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
   how_it_works_link_enable = static.get_value('HOW_IT_WORKS_LINK_ENABLE', settings.FEATURES.get('HOW_IT_WORKS_LINK_ENABLE', False))


### PR DESCRIPTION
Description
---------------
Using the DISABLE_LOGIN_BUTTON configuration we can hide or show the login and registration buttons in the navbar if it is not authenticated, by default True

**Ticket:** [PAE-660](https://pearsonadvance.atlassian.net/browse/PAE-660)