### PR TITLE
PAE-660.1 - Disable login/register button, update button label, and edit logo size 

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -452,7 +452,10 @@ label[for=register-password]{
   }
 
   .signin-logo {
-    width: 200px;
+    position: absolute;
+    right: 35px;
+    top: 15px;
+    width: 130px;
   }
 
   .login-container {
@@ -484,7 +487,9 @@ label[for=register-password]{
 
 @media (min-width: 1024px) {
   .signin-logo {
-    width: 180px;
+    right: 25px;
+    top: 22px;
+    width: 130px;
   }
 
   .signin-container {
@@ -495,7 +500,9 @@ label[for=register-password]{
 
 @media (min-width: 1280px) {
   .signin-logo {
-    width: 260px;
+    right: 55px;
+    top: 50px;
+    width: 150px;
   }
 
   .signin-container {
@@ -522,7 +529,9 @@ label[for=register-password]{
 
 @media (min-width: 1860px) {
   .signin-logo {
-    width: 320px;
+    width: 210px;
+    top: 50px;
+    right: 55px;
   }
 
   .signin-container {

--- a/edx-platform/pearson-vue-theme/lms/templates/index.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/index.html
@@ -8,9 +8,7 @@ from django.utils.translation import ugettext as _
 <div class="background-login"></div>
 
 <div class="login-container">
-  <div>
     <img class="signin-logo" src="/static/pearson-vue-theme/images/CertPREP_Logo.png">
-  </div>
   <div class="signin-container">
     <div class="toggle-form">
       <h1>${_("Welcome!")}</h1>
@@ -20,7 +18,7 @@ from django.utils.translation import ugettext as _
     <div class="login-providers">
       <a href="/login">
         <button class="button-vue">
-          <span aria-hidden="true">${_("Continue to sign in")}</span>
+          <span aria-hidden="true">${_("Continue")}</span>
           <span class="icon fa fa-arrow-right"></span>
         </button>
       </a>


### PR DESCRIPTION
# Description:
This PR hides the register/sign-in button using site configurations (DISABLE_LOGIN_BUTTON=true has to be added). Edits a button label directly in the html file. Also changes the size and location of the certPREP logo for width resolution greater than 768px.

Ticket: [PAE-660](https://pearsonadvance.atlassian.net/browse/PAE-660)

# Screenshots:
Changes Required:
![index](https://user-images.githubusercontent.com/40271196/119694491-e116f900-be12-11eb-9fbc-7b93d26256ab.png)

Changes Done:

1024x768 Resolution
![1024x768](https://user-images.githubusercontent.com/40271196/119691953-9eecb800-be10-11eb-80c9-49b20a6c9880.png)

768x1024 Resolution
![768x1024](https://user-images.githubusercontent.com/40271196/119691976-a2803f00-be10-11eb-9c24-20a9cd0343ac.png)

1280x800 Resolution
![1280x800](https://user-images.githubusercontent.com/40271196/119691991-a57b2f80-be10-11eb-96c6-8a0d59620832.png)

1440x900 Resolution
![1440x900](https://user-images.githubusercontent.com/40271196/119691995-a744f300-be10-11eb-8044-342c71b855c0.png)




