### PR TITLE
PAE-686.6 - Removing a max-width constraint in the Kaust theme.

### DIFF
--- a/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_index.scss
+++ b/edx-platform/pearson-kaust-theme/lms/static/sass/partials/lms/theme/_index.scss
@@ -33,6 +33,8 @@
 }
 
 .content-wrapper {
+  max-width: initial;
+
   &.main-container {
     margin-top: 0;
   }


### PR DESCRIPTION
## Description:

This PR removes the max-width constraint of the content-wrapper.

## Screenshots:

**Before:**
![Screen Shot 2021-06-16 at 16 19 42](https://user-images.githubusercontent.com/17520199/122295446-d0601d00-cebe-11eb-85b6-d79b22c5d2fe.png)

**After:**
![Screen Shot 2021-06-16 at 16 14 19](https://user-images.githubusercontent.com/17520199/122295465-d524d100-cebe-11eb-8f45-fcf6595813fc.png)

## Reviewers:

- [ ] @diegomillan 
- [ ] @ivanvgh 