### PR TITLE
PAE-777 - Change displayed currency

### DIFF
--- a/ecommerce/pols/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/pols/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -80,9 +80,28 @@
                             {% if line_data.line.has_discount %}
                                 <div class="discount">
                                     <div class="benefit">
-                                        {% blocktrans with benefit_value=line_data.benefit_value %}
-                                            {{ benefit_value }} off
-                                        {% endblocktrans %}
+                                        {% comment "Code explanation" %}
+                                            The line_data.benefit_value could be either a percentage or a currency
+                                            value (50.0% $50.0), This is an issue if the currency of the purchase is
+                                            different than the "$" symbol. The idea here is to get rid of the "$" symbol by applying the filter
+                                            |cut:"$" and then use the currency filter to format the value with the corresponding
+                                            purchase currency, |currency:line_data.line.price_currency.
+
+                                            Previous code:
+                                            {% blocktrans with benefit_value=line_data.benefit_value %}
+                                                {{ benefit_value }} off
+                                            {% endblocktrans %}
+                                        {% endcomment %}
+
+                                        {% if "$" in line_data.benefit_value %}
+                                            {% blocktrans with benefit_value=line_data.benefit_value|cut:"$"|currency:line_data.line.price_currency %}
+                                                {{ benefit_value }} off
+                                            {% endblocktrans %}
+                                        {% else %}
+                                            {% blocktrans with benefit_value=line_data.benefit_value %}
+                                                {{ benefit_value }} off
+                                            {% endblocktrans %}
+                                        {% endif %}
                                     </div>
                                     <div class="old-price">
                                         {{ line_data.line.line_price_incl_tax|currency:line_data.line.price_currency }}


### PR DESCRIPTION
# Description:

This PR is intended to make the benefit price of a coupon consistent with the currency of the purchase. The following screenshot illustrates the issue, there are both `$` and `£`.

Ticket: [PAE-777](https://pearsonadvance.atlassian.net/browse/PAE-777)

![$](https://user-images.githubusercontent.com/40271196/128237985-aa17424f-988f-42ac-8dc9-69feaaee5c4f.png)

# Changes done:

![$](https://user-images.githubusercontent.com/40271196/128237271-03e61522-0c23-491c-983c-19ae637bea55.png)

The changes do not affect the percentage discount.
![%](https://user-images.githubusercontent.com/40271196/128237284-7ae894ee-79d0-4cdf-9b3d-dee0335a9e9d.png)
