### PR TITLE
PAE-809-1- Removing GTM snippet insertion from themes. 

### DIFF
--- a/edx-platform/pearson-lbs-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-lbs-theme/lms/templates/footer.html
@@ -167,18 +167,6 @@
 </script>
 % endif
 
-% if False:
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=GOOGLE_TRACKING_ID"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'GOOGLE_TRACKING_ID');
-</script>
-% endif
-
 <% languages = released_languages() %>
 
 <script>

--- a/edx-platform/pearson-learninghub-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-learninghub-theme/lms/templates/header/header.html
@@ -38,10 +38,6 @@ theme = configuration_helpers.get_value('theme', '')
   unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS'))
 %>
 
-% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
-    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
-% endif
-
 % if waffle.switch_is_active('enable_unsupported_browser_alert'):
   <script>
     var $buoop = {

--- a/edx-platform/pearson-pathways-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/header/header.html
@@ -35,10 +35,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS'))
 %>
 
-% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
-    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
-% endif
-
 % if waffle.switch_is_active('enable_unsupported_browser_alert'):
   <script>
     var $buoop = {

--- a/edx-platform/pearson-pols-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/header/header.html
@@ -38,10 +38,6 @@ theme = configuration_helpers.get_value('theme', '')
   unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS'))
 %>
 
-% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
-    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
-% endif
-
 % if waffle.switch_is_active('enable_unsupported_browser_alert'):
   <script>
     var $buoop = {

--- a/edx-platform/pearson-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-theme/lms/templates/header/header.html
@@ -51,10 +51,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   </script>
 % endif
 
-% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
-    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
-% endif
-
 <header class="global-header ${'slim' if course else ''}">
     % if use_cookie_banner:
         ${static.renderReact(

--- a/edx-platform/pearson-ukl-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-ukl-theme/lms/templates/header/header.html
@@ -49,11 +49,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
     catch(e){window.attachEvent("onload", $buo_f)}
   </script>
-% endif
-
-% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
-    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
-% endif
 
 <header class="global-header ${'slim' if course else ''}">
     % if use_cookie_banner:

--- a/edx-platform/pearson-vue-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/header.html
@@ -35,10 +35,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS'))
 %>
 
-% if configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET'):
-    ${configuration_helpers.get_value('GOOGLE_TAG_MANAGER_SNIPPET') | n}
-% endif
-
 % if waffle.switch_is_active('enable_unsupported_browser_alert'):
   <script>
     var $buoop = {


### PR DESCRIPTION
### **Description:**

This PR removes the GTM snippet insertion in the themes templates, since it is being inserted inside of the lms main.html template as mentioned in [this PR](https://github.com/Pearson-Advance/edx-platform/pull/46). 

Context in [PAE-809.](https://pearsonadvance.atlassian.net/browse/PAE-809?atlOrigin=eyJpIjoiZjliNzY2NmVmYmIwNDg0NGEzMzJkY2RmMGYzM2M5MzMiLCJwIjoiaiJ9)