### PR TITLE
PAE-707-Adding time expiration warning and buy time extension button for MIT Hz courses.

### DIFF
--- a/edx-platform/pearson-pathways-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/dashboard.html
@@ -156,6 +156,34 @@ from student.models import CourseEnrollment
             'SOCIAL_SHARING_SETTINGS',
             getattr(settings, 'SOCIAL_SHARING_SETTINGS', {})
           )
+
+          # MIT subscription information to be displayed on course cards.
+          mit_subscription = {}
+
+          if configuration_helpers.get_value('ENABLE_MIT_HZ_SUBSCRIPTION', False):
+            try:
+              from course_modes.models import CourseMode
+              from openedx_external_enrollments.models import ExternalEnrollment
+
+              subscriptions = ExternalEnrollment.objects.filter(
+                controller_name='mit_hz',
+                email=user.email,
+              ).exclude(meta={})
+
+              # Retrieves the SKU from the verified enrollment mode. The reason is because when it is already verified,
+              # the course_mode_info object does not bring the sku anymore.
+              for subscription in subscriptions:
+                mit_subscription.update({
+                  str(subscription.course_shell): {
+                    'verified_sku': CourseMode.modes_for_course_dict(subscription.course_shell).get('verified').sku,
+                    'expires_at': datetime.strptime(
+                      subscription.meta.get('expires_at'),
+                      "%Y-%m-%dT%H:%M:%S.%fZ",
+                    ).strftime("%b %-d, %Y"),
+                  },
+                })
+            except:
+              pass
         %>
         % for dashboard_index, enrollment in enumerate(course_entitlements + course_enrollments):
         <div class="items course single-course">
@@ -215,7 +243,7 @@ from student.models import CourseEnrollment
           course_overview = enrollment.course_overview
           resume_button_url = resume_button_urls[dashboard_index]
         %>
-        <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url' />
+        <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, mit_subscription=mit_subscription' />
         </div>
         % endfor
       </div>

--- a/edx-platform/pearson-pathways-theme/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/dashboard/_dashboard_course_listing.html
@@ -1,4 +1,4 @@
-<%page args="course_overview, enrollment, entitlement, entitlement_session, course_card_index, is_unfulfilled_entitlement, is_fulfilled_entitlement, entitlement_available_sessions, entitlement_expiration_date, entitlement_expired_at, show_courseware_link, cert_status, can_refund_entitlement, can_unenroll, credit_status, show_email_settings, course_mode_info, is_paid_course, is_course_blocked, verification_status, course_requirements, dashboard_index, share_settings, related_programs, display_course_modes_on_dashboard, show_consent_link, enterprise_customer_name, resume_button_url" expression_filter="h"/>
+<%page args="course_overview, enrollment, entitlement, entitlement_session, course_card_index, is_unfulfilled_entitlement, is_fulfilled_entitlement, entitlement_available_sessions, entitlement_expiration_date, entitlement_expired_at, show_courseware_link, cert_status, can_refund_entitlement, can_unenroll, credit_status, show_email_settings, course_mode_info, is_paid_course, is_course_blocked, verification_status, course_requirements, dashboard_index, share_settings, related_programs, display_course_modes_on_dashboard, show_consent_link, enterprise_customer_name, resume_button_url, mit_subscription" expression_filter="h"/>
 
 <%!
 import six
@@ -37,6 +37,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
   billing_email = settings.PAYMENT_SUPPORT_EMAIL
 
   is_course_expired = hasattr(show_courseware_link, 'error_code') and show_courseware_link.error_code == 'audit_expired'
+  mit_subscription = mit_subscription.get(str(enrollment.course_id))
 %>
 
 <%namespace name='static' file='../static_content.html'/>
@@ -184,6 +185,13 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                         % endif
                 </div>
             % endif
+            % if mit_subscription and not course_mode_info['show_upsell']:
+              <div class="info-expires-at">
+                <span class="msg-icon fa fa-warning" aria-hidden="true"></span>
+                ${_("Your access expires on - {date}").format(date=mit_subscription.get('expires_at'))}
+              </div>
+            % endif
+
         </div>
         <div class="wrapper-course-actions">
           <div class="course-actions">
@@ -474,6 +482,16 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                 </a>
               </div>
             </div>
+          </div>
+        % endif
+        % if mit_subscription and not course_mode_info['show_upsell']:
+          <div class="message message-upsell has-actions is-shown">
+              <a class="action action-upgrade" href="${ecommerce_payment_page}?sku=${mit_subscription.get('verified_sku')}">
+                <span class="action-upgrade-icon" aria-hidden="true"></span>
+                <span class="wrapper-copy">
+                  <span class="copy" id="upgrade-to-verified">${_("Buy time extension")}</span>
+                </span>
+              </a>
           </div>
         % endif
       % endif

--- a/edx-platform/pearson-pols-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/dashboard.html
@@ -156,6 +156,34 @@ from student.models import CourseEnrollment
             'SOCIAL_SHARING_SETTINGS',
             getattr(settings, 'SOCIAL_SHARING_SETTINGS', {})
           )
+
+          # MIT subscription information to be displayed on course cards.
+          mit_subscription = {}
+
+          if configuration_helpers.get_value('ENABLE_MIT_HZ_SUBSCRIPTION', False):
+            try:
+              from course_modes.models import CourseMode
+              from openedx_external_enrollments.models import ExternalEnrollment
+
+              subscriptions = ExternalEnrollment.objects.filter(
+                controller_name='mit_hz',
+                email=user.email,
+              ).exclude(meta={})
+
+              # Retrieves the SKU from the verified enrollment mode. The reason is because when it is already verified,
+              # the course_mode_info object does not bring the sku anymore.
+              for subscription in subscriptions:
+                mit_subscription.update({
+                  str(subscription.course_shell): {
+                    'verified_sku': CourseMode.modes_for_course_dict(subscription.course_shell).get('verified').sku,
+                    'expires_at': datetime.strptime(
+                      subscription.meta.get('expires_at'),
+                      "%Y-%m-%dT%H:%M:%S.%fZ",
+                    ).strftime("%b %-d, %Y"),
+                  },
+                })
+            except:
+              pass
         %>
         % for dashboard_index, enrollment in enumerate(course_entitlements + course_enrollments):
         <div class="items course single-course">
@@ -215,7 +243,7 @@ from student.models import CourseEnrollment
           course_overview = enrollment.course_overview
           resume_button_url = resume_button_urls[dashboard_index]
         %>
-        <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url' />
+        <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, mit_subscription=mit_subscription' />
         </div>
         % endfor
       </div>

--- a/edx-platform/pearson-pols-theme/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/dashboard/_dashboard_course_listing.html
@@ -1,4 +1,4 @@
-<%page args="course_overview, enrollment, entitlement, entitlement_session, course_card_index, is_unfulfilled_entitlement, is_fulfilled_entitlement, entitlement_available_sessions, entitlement_expiration_date, entitlement_expired_at, show_courseware_link, cert_status, can_refund_entitlement, can_unenroll, credit_status, show_email_settings, course_mode_info, is_paid_course, is_course_blocked, verification_status, course_requirements, dashboard_index, share_settings, related_programs, display_course_modes_on_dashboard, show_consent_link, enterprise_customer_name, resume_button_url" expression_filter="h"/>
+<%page args="course_overview, enrollment, entitlement, entitlement_session, course_card_index, is_unfulfilled_entitlement, is_fulfilled_entitlement, entitlement_available_sessions, entitlement_expiration_date, entitlement_expired_at, show_courseware_link, cert_status, can_refund_entitlement, can_unenroll, credit_status, show_email_settings, course_mode_info, is_paid_course, is_course_blocked, verification_status, course_requirements, dashboard_index, share_settings, related_programs, display_course_modes_on_dashboard, show_consent_link, enterprise_customer_name, resume_button_url, mit_subscription" expression_filter="h"/>
 
 <%!
 import six
@@ -37,6 +37,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
   billing_email = settings.PAYMENT_SUPPORT_EMAIL
 
   is_course_expired = hasattr(show_courseware_link, 'error_code') and show_courseware_link.error_code == 'audit_expired'
+  mit_subscription = mit_subscription.get(str(enrollment.course_id))
 %>
 
 <%namespace name='static' file='../static_content.html'/>
@@ -173,6 +174,12 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                             ${_('You can change sessions until {entitlement_expiration_date}.').format(entitlement_expiration_date=entitlement_expiration_date)}
                         % endif
                 </div>
+            % endif
+            % if mit_subscription and not course_mode_info['show_upsell']:
+              <div class="info-expires-at">
+                <span class="msg-icon fa fa-warning" aria-hidden="true"></span>
+                ${_("Your access expires on - {date}").format(date=mit_subscription.get('expires_at'))}
+              </div>
             % endif
         </div>
         <div class="wrapper-course-actions">
@@ -464,6 +471,16 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                 </a>
               </div>
             </div>
+          </div>
+        % endif
+        % if mit_subscription and not course_mode_info['show_upsell']:
+          <div class="message message-upsell has-actions is-shown">
+              <a class="action action-upgrade" href="${ecommerce_payment_page}?sku=${mit_subscription.get('verified_sku')}">
+                <span class="action-upgrade-icon" aria-hidden="true"></span>
+                <span class="wrapper-copy">
+                  <span class="copy" id="upgrade-to-verified">${_("Buy time extension")}</span>
+                </span>
+              </a>
           </div>
         % endif
       % endif


### PR DESCRIPTION
### **Description:**
This PR adds a logic to show expiration time warning for courses from MIT Hz, also as it is treated as a subscription way, a new button to to purchase time extension was added.

More context in [PAE-707.](https://pearsonadvance.atlassian.net/browse/PAE-707?atlOrigin=eyJpIjoiNWFlYTIyNDFmYjVhNGQyMjkyYTliYzBkMTViMmRhZWQiLCJwIjoiaiJ9)