### PR TITLE
Adding missing 'endif' keyword.

### DIFF
--- a/edx-platform/pearson-ukl-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-ukl-theme/lms/templates/header/header.html
@@ -49,6 +49,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
     catch(e){window.attachEvent("onload", $buo_f)}
   </script>
+% endif
 
 <header class="global-header ${'slim' if course else ''}">
     % if use_cookie_banner:


### PR DESCRIPTION
This is causing a 500 error for the ukl site, after login. We need to apply the hotfix ASAP.

@ivanvgh @Squirrel18 @Alec4r 