### PR TITLE
PAE-666-1 - Removes certificates header for Pathways theme.

### DIFF
--- a/edx-platform/pearson-pathways-theme/lms/templates/certificates/_accomplishment-header.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/certificates/_accomplishment-header.html
@@ -1,0 +1,15 @@
+<%page expression_filter="h"/>
+<%! from django.utils.translation import ugettext as _ %>
+
+<div class="wrapper-header">
+
+    <header class="header-app" role="banner">
+        <h1 class="header-app-title">
+            <a class="logo" href="${logo_url}">
+                <img class="logo-img" src="${logo_src}" alt="${_('{platform_name} Home').format(platform_name=platform_name)}" />
+            </a>
+            <span class="sr-only">${logo_subtitle}</span>
+        </h1>
+    </header>
+
+</div>

--- a/edx-platform/pearson-pathways-theme/lms/templates/certificates/_accomplishment-header.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/certificates/_accomplishment-header.html
@@ -1,15 +1,6 @@
-<%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
-
-<div class="wrapper-header">
-
-    <header class="header-app" role="banner">
-        <h1 class="header-app-title">
-            <a class="logo" href="${logo_url}">
-                <img class="logo-img" src="${logo_src}" alt="${_('{platform_name} Home').format(platform_name=platform_name)}" />
-            </a>
-            <span class="sr-only">${logo_subtitle}</span>
-        </h1>
-    </header>
-
-</div>
+## Style attached in this file because it is outside lms/static/sass/ and it is not being applied when overridden.
+<style>
+    .wrapper-view {
+        margin-top: 40px;
+    }
+</style>


### PR DESCRIPTION
### Description:

This PR removes certificates header.
Styles changes are being applied in the same html file due to the css class does not belong to 'lms/static/sass/partials' and this can be a reason why changes in sass file regarding this style are not reflected.
Context can be found in [PAE-666](https://pearsonadvance.atlassian.net/browse/PAE-666?atlOrigin=eyJpIjoiYmE1NDhmNGM1YTM2NDEzZDkxM2UwNTRkOTQyNzUxZjgiLCJwIjoiaiJ9).

Note: This change was made for the other themes before pathways, now the same change is being applied for the Pathways theme as well.

### Reviewers:

- [ ] @Squirrel18 
- [ ] @diegomillan 