### PR TITLE
PAE- 707.1 - Prevent date format inconsistence.

### DIFF
--- a/edx-platform/pearson-pathways-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/dashboard.html
@@ -162,6 +162,8 @@ from student.models import CourseEnrollment
 
           if configuration_helpers.get_value('ENABLE_MIT_HZ_SUBSCRIPTION', False):
             try:
+              from dateutil import parser as date_parser
+
               from course_modes.models import CourseMode
               from openedx_external_enrollments.models import ExternalEnrollment
 
@@ -176,10 +178,7 @@ from student.models import CourseEnrollment
                 mit_subscription.update({
                   str(subscription.course_shell): {
                     'verified_sku': CourseMode.modes_for_course_dict(subscription.course_shell).get('verified').sku,
-                    'expires_at': datetime.strptime(
-                      subscription.meta.get('expires_at'),
-                      "%Y-%m-%dT%H:%M:%S.%fZ",
-                    ).strftime("%b %-d, %Y"),
+                    'expires_at': date_parser.parse(subscription.meta.get('expires_at')).strftime("%b %-d, %Y"),
                   },
                 })
             except:

--- a/edx-platform/pearson-pols-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-pols-theme/lms/templates/dashboard.html
@@ -162,6 +162,8 @@ from student.models import CourseEnrollment
 
           if configuration_helpers.get_value('ENABLE_MIT_HZ_SUBSCRIPTION', False):
             try:
+              from dateutil import parser as date_parser
+
               from course_modes.models import CourseMode
               from openedx_external_enrollments.models import ExternalEnrollment
 
@@ -176,10 +178,7 @@ from student.models import CourseEnrollment
                 mit_subscription.update({
                   str(subscription.course_shell): {
                     'verified_sku': CourseMode.modes_for_course_dict(subscription.course_shell).get('verified').sku,
-                    'expires_at': datetime.strptime(
-                      subscription.meta.get('expires_at'),
-                      "%Y-%m-%dT%H:%M:%S.%fZ",
-                    ).strftime("%b %-d, %Y"),
+                    'expires_at': date_parser.parse(subscription.meta.get('expires_at')).strftime("%b %-d, %Y"),
                   },
                 })
             except:


### PR DESCRIPTION
### **Description:**
This PR adds handling to parse  different date formats for the subscription expiration time since the MIT Hz API return 2 formats like the following:
`"2021-09-10T11:33:25.036Z"`
`"2021-10-22T11:33:25Z"`

Note. With the usage of `dateutil.parse` we avoid defining each date format.