### PR TITLE
PAE-777.2 - Change displayed currency for Pathways.

### DIFF
--- a/ecommerce/pathways/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/pathways/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -68,9 +68,27 @@
                                 <div class="discount">
                                     <div class="benefit">
                                         {% filter force_escape %}
+                                        {% comment "Code explanation" %}
+                                        The line_data.benefit_value could be either a percentage or a currency
+                                        value (50.0% $50.0), This is an issue if the currency of the purchase is
+                                        different than the "$" symbol. The idea here is to get rid of the "$" symbol by applying the filter
+                                        |cut:"$" and then use the currency filter to format the value with the corresponding
+                                        purchase currency, |currency:line_data.line.price_currency.
+                                        Previous code:
                                         {% blocktrans with benefit_value=line_data.benefit_value %}
                                             {{ benefit_value }} off
                                         {% endblocktrans %}
+                                        {% endcomment %}
+
+                                        {% if "$" in line_data.benefit_value %}
+                                            {% blocktrans with benefit_value=line_data.benefit_value|cut:"$"|currency:line_data.line.price_currency %}
+                                                {{ benefit_value }} off
+                                            {% endblocktrans %}
+                                        {% else %}
+                                            {% blocktrans with benefit_value=line_data.benefit_value %}
+                                                {{ benefit_value }} off
+                                            {% endblocktrans %}
+                                        {% endif %}
                                         {% endfilter %}
                                     </div>
                                     <div class="old-price">


### PR DESCRIPTION
## Description:
This PR applies the same change as in [PAE-777 - Change displayed currency](https://github.com/Pearson-Advance/openedx-themes/pull/159) but to the Pathways Theme. So, this PR fixes the inconsistency of having two different currency symbols `$` and `£`. You can see the issue in the following picture:

![image](https://user-images.githubusercontent.com/40271196/138712222-3b18de6a-2032-4076-9d80-41c544c80a2d.png)


Ticket: [PAE-777](https://pearsonadvance.atlassian.net/browse/PAE-777)

## Changes done:
![image](https://user-images.githubusercontent.com/40271196/138713449-82680f4e-df05-4c09-a320-9bcf2ff593ff.png)

The changes do not affect the percentage discount.

![image](https://user-images.githubusercontent.com/40271196/138704619-c5ac77a4-f280-4c52-a746-adb7d7692adf.png)

