### PR TITLE
PADV-48 - Add condition to allow unenrollment.

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
@@ -1,0 +1,102 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<h2 class="hd hd-2">${_("Enrollment")}</h2>
+<div class="batch-enrollment-ccx">
+  <form method="POST" action="ccx-manage-students">
+  <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
+  <label for="student-ids" class="sr">${_("Email Addresses/Usernames")}</label>
+  <p id="label_student_ids" class="text-helper">
+      ${_("Enter one or more email addresses or usernames separated by new lines or commas.")}
+      ${_("Make sure you enter the information carefully. You will not receive notification for invalid usernames or email addresses.")}
+  </p>
+  <textarea rows="6" name="student-ids" id="student-ids" aria-describedby="label_student_ids" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
+
+
+  <div class="enroll-option">
+    <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="auto-enroll-helper" disabled>
+    <label style="display:inline" for="auto-enroll">${_("Auto Enroll")}</label>
+    <div class="hint auto-enroll-hint">
+      <span class="hint-caret"></span>
+      <p class="text-helper" id="auto-enroll-helper">
+	${Text(_("If this option is {em_start}checked{em_end}, users who have not yet registered for {platform_name} will be automatically enrolled.")).format(
+        em_start=HTML('<em>'),
+        em_end=HTML('</em>'),
+        platform_name=settings.PLATFORM_NAME,
+    )}
+	${Text(_("If this option is left {em_start}unchecked{em_end}, users who have not yet registered for {platform_name} will not be enrolled, but will be allowed to enroll once they make an account.")).format(
+        em_start=HTML('<em>'),
+        em_end=HTML('</em>'),
+        platform_name=settings.PLATFORM_NAME,
+    )}
+	<br /><br />
+	${_("Checking this box has no effect if 'Unenroll' is selected.")}
+      </p>
+    </div>
+  </div>
+
+  <div class="enroll-option">
+    <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" checked="yes" aria-describedby="email-students-helper">
+    <label style="display:inline" for="email-students">${_("Notify users by email")}</label>
+    <div class="hint email-students-hint">
+      <span class="hint-caret"></span>
+      <p class="text-helper" id="email-students-helper">
+	${Text(_("If this option is {em_start}checked{em_end}, users will receive an email notification.")).format(
+        em_start=HTML('<em>'),
+        em_end=HTML('</em>'),
+    )}
+      </p>
+    </div>
+  </div>
+
+  <div>
+    <input type="submit" name="enrollment-button" class="enrollment-button" value="${pgettext('someone','Enroll')}">
+    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
+  </div>
+  <div class="request-response"></div>
+  <div class="request-response-error"></div>
+  </form>
+</div>
+
+<div class="member-lists-management-ccx">
+  <form method="POST" action="ccx-manage-students" class="ccx-manage-student-form">
+  <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
+  <div class="auth-list-container active">
+    <div class="member-list-widget">
+      <div class="member-list">
+        <h2 class="hd hd-2">${_("Student List Management")}</h2>
+        %if messages:
+          <label for="ccx_std_list_messages" class="sr">${_("CCX student list management response message")}</label>
+          <div id="ccx_std_list_messages" tabindex="-1" class="request-response-error">
+            %for message in messages:
+              ${message}
+            %endfor
+          </div>
+        %endif
+        <table>
+          <thead>
+            <tr>
+              <th class="label" scope="col">${_("Username")}</th>
+              <th class="label" scope="col">${_("Email")}</th>
+              <th class="label" scope="col">${_("Revoke access")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            %for member in ccx_members:
+            <tr>
+              <td>${member.user}</td>
+              <td>${member.user.email}</td>
+              <td><button type="button" class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span>${_("Revoke access")}</button></td>
+            </tr>
+            %endfor
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  </form>
+</div>

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
@@ -3,6 +3,19 @@
 from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+    allow_ccx_unenroll = True
+
+    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and not configuration_helpers.get_value('ALLOW_CCX_UNENROLL', True):
+        try:
+            from pearson_course_operation.utils import is_ccx_license_managed
+
+            allow_ccx_unenroll = not is_ccx_license_managed(course.id)
+        except ImportError:
+            pass
 %>
 
 <h2 class="hd hd-2">${_("Enrollment")}</h2>
@@ -55,7 +68,9 @@ from openedx.core.djangolib.markup import HTML, Text
 
   <div>
     <input type="submit" name="enrollment-button" class="enrollment-button" value="${pgettext('someone','Enroll')}">
-    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
+    %if allow_ccx_unenroll:
+      <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
+    %endif
   </div>
   <div class="request-response"></div>
   <div class="request-response-error"></div>
@@ -82,16 +97,24 @@ from openedx.core.djangolib.markup import HTML, Text
             <tr>
               <th class="label" scope="col">${_("Username")}</th>
               <th class="label" scope="col">${_("Email")}</th>
-              <th class="label" scope="col">${_("Revoke access")}</th>
+              %if allow_ccx_unenroll:
+                <th class="label" scope="col">${_("Revoke access")}</th>
+              %endif
             </tr>
           </thead>
           <tbody>
             %for member in ccx_members:
-            <tr>
-              <td>${member.user}</td>
-              <td>${member.user.email}</td>
-              <td><button type="button" class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span>${_("Revoke access")}</button></td>
-            </tr>
+              <tr>
+                <td>${member.user}</td>
+                <td>${member.user.email}</td>
+                %if allow_ccx_unenroll:
+                  <td>
+                    <button type="button" class="revoke">
+                      <span class="fa fa-times-circle" aria-hidden="true"></span>${_("Revoke access")}
+                    </button>
+                  </td>
+                %endif
+              </tr>
             %endfor
           </tbody>
         </table>


### PR DESCRIPTION
### Description:
This PR adds a condition to hide/show the **_revoke access_** and **_enroll_** buttons from CCX coach dashboard.

More context in [PADV-48](https://agile-jira.pearson.com/browse/PADV-48).

**Note:** ` ALLOW_CCX_UNENROLL` is by default True and the `PCO_ENABLE_LICENSE_ENFORCEMENT` flag turned on lets the platform check if the current CCX is license managed, if that is the case it won't show the revoke-access button.

Before:
![Screenshot from 2021-11-10 18-38-56](https://user-images.githubusercontent.com/36037715/141210939-c7541005-7577-430d-a0f0-ab8942187228.png)


After:
![Screenshot from 2021-11-10 18-38-06](https://user-images.githubusercontent.com/36037715/141210891-036c7d47-7ac2-47b7-a0bd-26ed97a7b582.png)

