### PR TITLE
PAE-849 Update Pathways footer

### DIFF
--- a/edx-platform/pearson-pathways-theme/lms/static/sass/partials/lms/theme/_footer.scss
+++ b/edx-platform/pearson-pathways-theme/lms/static/sass/partials/lms/theme/_footer.scss
@@ -1,7 +1,6 @@
 // Styles for the footer template.
 
 $line-color: rgba(255,255,255,0.2);
-$letter-spacing: 2.6px;
 $main-font-size: 0.875em;
 
 .wrapper-footer {
@@ -11,7 +10,7 @@ $main-font-size: 0.875em;
 
   footer {
     // Reset Bootstrap "container" style.
-    max-width: 1200px !important;
+    max-width: 1170px !important;
     padding: 40px 0 0 0;
 
     // There is a generic style similar applying div and box shadow on the wiki page of course.
@@ -26,6 +25,7 @@ $main-font-size: 0.875em;
     .row {
       margin-right: initial;
       margin-left: initial;
+      margin-bottom: 60px;
     }
 
     .wrapper-logo {
@@ -34,11 +34,16 @@ $main-font-size: 0.875em;
       }
 
       h4 {
-        font-family: $serif;
-        font-size: 1.25em;
+        font-family: $font-family-sans-serif;
+        font-weight: 600;
+        line-height: 28px;
         color: $inverse;
         margin-top: 12px;
       }
+    }
+
+    .icon-background {
+      color: $inverse;
     }
 
     .social-links {
@@ -50,7 +55,7 @@ $main-font-size: 0.875em;
         margin: 0 14px 0 0;
 
         a {
-          color: $footer-contrast;
+          color: $footer-background;
         }
       }
     }
@@ -59,18 +64,18 @@ $main-font-size: 0.875em;
       padding-left: 50px;
 
       h4 {
-        font-family: $serif;
-        font-size: 1.1em;
-        font-weight: 700;
+        font-family: $font-family-sans-serif;
+        font-weight: 600;
+        line-height: 28px;
         color: $inverse;
         margin-bottom: 18px;
       }
 
       p {
-        margin-bottom: 30px;
+        margin-bottom: 10px;
+        font-family: $font-family-sans-serif;
         font-size: $main-font-size;
-        letter-spacing: $letter-spacing;
-
+        line-height: 26px;
         a {
           color: $footer-contrast;
         }
@@ -81,18 +86,19 @@ $main-font-size: 0.875em;
   .legal-nav {
     border-top: solid 1px $line-color;
     padding: 0 14px 0 0;
-    margin-top: 50px;
+    margin-top: 35px;
 
     ul {
       list-style: none;
       padding: 0;
-      margin-top: 40px;
+      margin-top: 20px;
 
       li {
         display: inline-block;
         margin: 0 42px 0 0;
+        font-family: $font-family-sans-serif;
         font-size: $main-font-size;
-        letter-spacing: $letter-spacing;
+        line-height: 21px;
 
         a {
           color: $footer-contrast;
@@ -104,25 +110,27 @@ $main-font-size: 0.875em;
       }
     }
 
-    .copyright {
-      margin-top: 60px;
+    .notice {
+      color: $inverse;
       color: $footer-contrast;
-      font-size: $main-font-size;
-      letter-spacing: $letter-spacing;
       text-transform: capitalize;
+      font-family: $font-family-sans-serif;
+      font-size: $main-font-size;
+      line-height: 21px;
+    }
+
+    .copyright {
+      margin-top: 20px;
+      color: $footer-contrast;
+      text-transform: capitalize;
+      font-family: $font-family-sans-serif;
+      font-size: $main-font-size;
+      line-height: 21px;
 
       a {
         color: $footer-contrast;
       }
     }
-  }
-
-  .notice {
-    color: $inverse;
-    font-family: $font-family-sans-serif;
-    line-height: 2em;
-    font-size: $main-font-size;
-    font-weight: bold;
   }
 
   .footer-about-openedx {

--- a/edx-platform/pearson-pathways-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/footer.html
@@ -33,57 +33,70 @@
         <ul class="social-links">
           <li>
             <a href="https://www.facebook.com/PearsonPathways" target="_blank" aria-label="Facebook">
-              <i class="fa fa-facebook" aria-hidden="true"></i>
+              <span class="fa-stack">
+                <i class="fa fa-circle fa-stack-2x icon-background"></i>
+                <i class="fa fa-facebook fa-stack-1x"></i>
+              </span>
             </a>
           </li>
           <li>
             <a href="https://www.twitter.com/PearsonPathways" target="_blank" aria-label="Twitter">
-              <i class="fa fa-twitter" aria-hidden="true"></i>
+              <span class="fa-stack">
+                <i class="fa fa-circle fa-stack-2x icon-background"></i>
+                <i class="fa fa-twitter fa-stack-1x"></i>
+              </span>
             </a>
           </li>
           <li>
             <a href="https://www.linkedin.com/company/pearson-pathways" target="_blank" aria-label="LinkedIn">
-              <i class="fa fa-linkedin" aria-hidden="true"></i>
+              <span class="fa-stack">
+                <i class="fa fa-circle fa-stack-2x icon-background"></i>
+                <i class="fa fa-linkedin fa-stack-1x"></i>
+              </span>
             </a>
           </li>
           <li>
             <a href="https://www.instagram.com/pearsonpathways/" target="_blank" aria-label="Instagram">
-              <i class="fa fa-instagram" aria-hidden="true"></i>
+              <span class="fa-stack">
+                <i class="fa fa-circle fa-stack-2x icon-background"></i>
+                <i class="fa fa-instagram fa-stack-1x"></i>
+              </span>
             </a>
           </li>
         </ul>
       </div>
       <div class="col-md-4 col-12 mid-footer-container">
         <h4>Students</h4>
-        <p><a href="https://www.pearson.com/pathways/recommended-programs.html">GET RECOMMENDATIONS</a></p>
-        <p><a href="https://www.pearson.com/pathways/compare.html">COMPARE PROGRAMS</a></p>
-        <p><a href="https://www.pearson.com/pathways/program-profiles.html">DEGREES, CERTIFICATES &amp; COURSES</a></p>
-        <p><a href="https://www.pearson.com/pathways/areas-work-study.html">AREAS OF WORK &amp; STUDY</a></p>
-        <h4>Colleges &amp; Universities<br></h4>
-        <p><a href="https://www.pearson.com/pathways/partner-with-us.html">JOIN THE PATHWAYS MARKETPLACE</a></p>
+        <p><a href="https://www.pearson.com/pathways/learner-profile.html/account">My Learner Profile</a></p>
+        <p><a href="https://www.pearson.com/pathways/recommended-programs.html">Get Recommendations</a></p>
+        <p><a href="https://www.pearson.com/pathways/areas-work-study.html">View Areas of Study</a></p>
+        <p><a href="https://www.pearson.com/pathways/program-profiles.html">Degrees, Courses &amp; Certificates</a></p>
+        <p><a href="https://www.pearson.com/pathways/student-resources.html">Student Resources</a></p>
+        <p><a href="https://www.pearson.com/pathways/blog.html">Education news and trends</a></p>
       </div>
       <div class="col-md-4 col-12 mid-footer-container">
         <h4>Company</h4>
-        <p><a href="https://www.pearson.com/pathways/about.html">ABOUT US</a></p>
-        <p><a href="https://www.pearson.com/pathways/learner-profile.html/account">MY ACCOUNT</a></p>
-        <p><a href="https://www.pearson.com/pathways/request-information.html">REQUEST FOR INFORMATION</a></p>
-        <p><a href="https://www.pearson.com/pathways/contact.html">CONTACT US</a></p>
+        <p><a href="https://www.pearson.com/pathways/about.html">About Pearson Pathways</a></p>
+        <p><a href="https://www.pearson.com/pathways/request-information.html">Request for information</a></p>
+        <p><a href="https://www.pearson.com/pathways/contact.html">Contact us</a></p> <br> <br>
+        <h4>Colleges &amp; Universities</h4>
+        <p><a href="https://www.pearson.com/pathways/partner-with-us.html">Join the pathways Marketplace</a></p>
       </div>
       <div class="col-12 legal-nav">
         <ul>
-            <li><a href="https://www.pearson.com/pathways/terms-of-use.html">TERMS OF USE</a></li>
-            <li><a href="https://www.pearson.com/pathways/privacy-policy.html">PRIVACY POLICY</a></li>
-            <li><a href="https://www.pearson.com/pathways/do-not-sell-my-information.html">DO NOT SELL MY PERSONAL INFORMATION</a><br></li>
-            <li><a href="https://www.pearson.com/pathways/complaint-resolution.html">COMPLAINT RESOLUTION</a></li>
+            <li><a href="https://www.pearson.com/pathways/terms-of-use.html">Terms of use</a></li>
+            <li><a href="https://www.pearson.com/pathways/privacy-policy.html">Privacy policy</a></li>
+            <li><a href="https://www.pearson.com/pathways/do-not-sell-my-information.html">Do not sell my personal information</a><br></li>
+            <li><a href="https://www.pearson.com/pathways/complaint-resolution.html">Complaint resolution</a></li>
         </ul>
-        <p class="copyright">Copyright ©&nbsp;1996–${datetime.today().year}&nbsp;
-          <a href="https://www.pearson.com" aria-label="Pearson" title="Pearson">PEARSON</a>&nbsp;
-          All rights reserved.
-        </p>
         <p class="notice">
           Tuition, fees, and dates may be subject to change without notice by university,
           administrative, federal, or state legislative changes. <br>
           Consult with the specific institution for more specific information.
+        </p>
+        <p class="copyright">Copyright ©&nbsp;1996–${datetime.today().year}&nbsp;
+          <a href="https://www.pearson.com" aria-label="Pearson" title="Pearson">Pearson</a>&nbsp;
+          All rights reserved.
         </p>
       </div>
     </div>


### PR DESCRIPTION
The objective of this PR is update the footer of pearson-pathways-theme, following the guidelines of figma:

https://pearsonadvance.atlassian.net/browse/PAE-849, 
https://www.figma.com/file/xShZyCR6BCyvmtmJ7pZVjc/Intermidiate-DS?node-id=347%3A8677

The footer before the changes is:

![Selection_193](https://user-images.githubusercontent.com/30726391/145137115-484b908d-b39e-489b-beb8-ccd5e791af44.png)

The footer after the changes is:

![Selection_194](https://user-images.githubusercontent.com/30726391/145137151-6bc1ff68-f38b-4c0a-a58a-d8268e7077c8.png)

