### PR TITLE
Pearson/PAE-849 change p of pathways to uppercase

### DIFF
--- a/edx-platform/pearson-pathways-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-pathways-theme/lms/templates/footer.html
@@ -80,7 +80,7 @@
         <p><a href="https://www.pearson.com/pathways/request-information.html">Request for information</a></p>
         <p><a href="https://www.pearson.com/pathways/contact.html">Contact us</a></p> <br> <br>
         <h4>Colleges &amp; Universities</h4>
-        <p><a href="https://www.pearson.com/pathways/partner-with-us.html">Join the pathways Marketplace</a></p>
+        <p><a href="https://www.pearson.com/pathways/partner-with-us.html">Join the Pathways Marketplace</a></p>
       </div>
       <div class="col-12 legal-nav">
         <ul>


### PR DESCRIPTION
Under College & Universities capitalize ‘pathways’.  It should be ‘Join the Pathways Marketplace’.

![image](https://user-images.githubusercontent.com/30726391/146960307-eb66e19d-211e-46ad-aeb6-2e21e534d2d4.png)