### PR TITLE
PAE-105.1 - Get legal nav links from MKTG.

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/templates/footer.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/footer.html
@@ -24,13 +24,15 @@
 
         <nav class="nav-legal" aria-label="${_('Legal')}">
           <ul>
-            <li class="nav-legal-01">
-              <a href="${MKTG_URL_PRIVACY}">${_('Privacy policy')}</a>
-            </li>
-
-            <li class="nav-legal-02">
-              <a href="${MKTG_URL_TOS}">${_('Terms of service')}</a>
-            </li>
+            % for item_num, link in enumerate(footer['legal_links'], start=1):
+              ## Remove the Honor Code link.
+              % if link['name'] == 'honor_code':
+                <% continue %>
+              % endif
+              <li class="nav-legal-0${item_num}">
+                <a href="${link['url']}">${link['title']}</a>
+              </li>
+            % endfor
           </ul>
         </nav>
 


### PR DESCRIPTION
## Description:

This PR adds the ability to obtain the legal nav links on the footer from the MKTG overrides in the site configuration.

## Reviewers:

. [ ] @Jacatove 