### PR TITLE
PAE-144 - fix: blocktrans was not translated due to the markup.

### DIFF
--- a/ecommerce/pols/templates/edx/checkout/receipt.html
+++ b/ecommerce/pols/templates/edx/checkout/receipt.html
@@ -2,6 +2,7 @@
 {% load core_extras %}
 {% load currency_filters %}
 {% load i18n %}
+{% load django_markup %}
 {% load l10n %}
 {% load offer_tags %}
 {% load static %}
@@ -43,11 +44,12 @@
                       {{ link_start }}{{ email }}{{ link_end }}. If you need a receipt, you can print this page.
                   {% endblocktrans %}
               {% else %}
-                  {% blocktrans trimmed with email=order.user.email link_end="</a>" %}
+                  {% blocktrans trimmed asvar tmsg %}
                       Your order is complete. If you need a receipt, you can print this page.
                       You will also receive a confirmation message with this information at
-                      {{ link_start }}{{ email }}{{ link_end }}.
+                      {link_start}{email}{link_end}.
                   {% endblocktrans %}
+                {% interpolate_html tmsg email=order.user.email|safe link_end="</a>"|safe link_start=link_start|safe %}
               {% endif %}
             </div>
 


### PR DESCRIPTION
## Description:

This PR is intended to fix the markup issue regarding a blocktrans and the corresponding translations, which doesn't allow the receipt page to translate eventhoug there is a translation for it:
```
"Your order is complete. If you need a receipt, you can print this page. You "
"will also receive a confirmation message with this information at "
```

The previous text is what is shown, and the following translation is what should be displayed.

```
#: ecommerce/templates/edx/checkout/receipt.html:59
#, python-brace-format
msgid ""
"Your order is complete. If you need a receipt, you can print this page. You "
"will also receive a confirmation message with this information at "
"{link_start}{email}{link_end}."
msgstr "Su pedido está completo. Si necesita un recibo, puede imprimir esta página. También recibirá un mensaje de confirmación con este mensaje en {link_start}{email}{link_end}."

```

The previous translation does not match with the current blocktrans, that's the root of the issue.