### PR TITLE
PAE-153 - feat: add custom_settings.find_more_courses_link support in receipt.

### DIFF
--- a/ecommerce/pols/templates/edx/checkout/receipt.html
+++ b/ecommerce/pols/templates/edx/checkout/receipt.html
@@ -188,7 +188,7 @@
             {% trans "Go to dashboard" %}
           </a>
           {% endif %}
-          <a class="find-more-courses-link nav-link" href="https://pearsonx.pearson.com/?s=">
+          <a class="find-more-courses-link nav-link" href="{{ custom_settings.find_more_courses_link|default:explore_courses_url }}">
             {% trans "Find more courses" %}
           </a>
         </div>


### PR DESCRIPTION
## Description:

This PR adds support to the receipt page to set the redirect URL for `"Find more courses"` , based on the `"find_more_courses_link"` custom site configuration in the eCommerce site. This changed is applied to the **pols** theme.

**Ticket:** [PAE-153](https://agile-jira.pearson.com/browse/PAE-153)

## Testing Instructions:
1. Make sure you have configured the **pols** theme for your eCommerce and . 
![image](https://user-images.githubusercontent.com/40271196/171647284-4ec8a89f-e5ed-45fd-846e-777a43a30403.png)
2. Configure the Custom settings in site configuration to set the following variable in http://ecommerce.main.localhost:18130/admin/core/siteconfiguration/:
```
{...
"find_more_courses_link":"http://lms.main.localhost:18000/courses"
}
```
3. Check if you have already purchased a course in Order History Tab in your account (LMS), if there is at least one, click on **order details**, then you should be redirected to eComm. In case you haven't purchased any course, you will need to do so, and you will be automatically redirected to the Receipt Page where this PR's change takes place.
![image](https://user-images.githubusercontent.com/40271196/171648130-673c9deb-1090-4763-8230-87a143518a44.png)

4. In the receipt page, click on the Find More Courses button and verify that you are redirected to the URL to set in the step 2.
![image](https://user-images.githubusercontent.com/40271196/171649615-a296b39d-6272-4be8-9794-879dc0fd791f.png)




