### PR TITLE
PADV-152 - Change CCX course name.

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/static/sass/partials/lms/theme/_ccx-course-name.scss
+++ b/edx-platform/pearson-certiport-theme/lms/static/sass/partials/lms/theme/_ccx-course-name.scss
@@ -1,0 +1,50 @@
+// Styles for lms/templates/ccx/course_name.html.
+
+.ccx-change-course-name-feedback {
+  display: none;
+  margin: 0.5em 0;
+}
+
+.ccx-change-course-name-spinner {
+  display: none;
+  -webkit-animation: ccx-spinner-loading-rotate 2s infinite linear; /* Safari 4+ */
+  -moz-animation: ccx-spinner-loading-rotate 2s infinite linear; /* Fx 5+ */
+  -o-animation: ccx-spinner-loading-rotate 2s infinite linear; /* Opera 12+ */
+  animation: ccx-spinner-loading-rotate 2s infinite linear; /* IE 10+, Fx 29+ */
+}
+
+@-webkit-keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+
+@-moz-keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+
+@-o-keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+
+@keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}

--- a/edx-platform/pearson-certiport-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-certiport-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -9,3 +9,4 @@
 @import 'index';
 @import 'navigation';
 @import 'footer';
+@import 'ccx-course-name';

--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/coach_dashboard.html
@@ -67,6 +67,9 @@ from openedx.core.djangolib.js_utils import (
             <li class="nav-item">
               <button type="button" class="btn-link" data-section="grading_policy">${_("Grading Policy")}</button>
             </li>
+            <li class="nav-item">
+              <button type="button" class="btn-link" data-section="course_name">${_("Course Name")}</button>
+            </li>
           </ul>
           <section id="membership" class="idash-section" aria-label="${_('Batch Enrollment')}">
             <%include file="enrollment.html" args="" />
@@ -79,6 +82,9 @@ from openedx.core.djangolib.js_utils import (
           </section>
           <section id="grading_policy" class="idash-section" aria-label="${_('Grading Policy')}">
             <%include file="grading_policy.html" args="" />
+          </section>
+          <section id="course_name" class="idash-section" aria-label="${_('Course Name')}">
+            <%include file="course_name.html" args="" />
           </section>
           %endif
 

--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/course_name.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/course_name.html
@@ -1,0 +1,52 @@
+<%page expression_filter="h"/>
+<%!
+  from django.utils.translation import ugettext as _
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+  from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+  )
+%>
+
+<%ALTERNAVITE_STRINGS = configuration_helpers.get_value('ALTERNAVITE_STRINGS', {})%>
+
+<h2 class="hd hd-2">${_(ALTERNAVITE_STRINGS.get("Change CCX course name.", "Change CCX course name."))}</h2>
+<hr>
+<p>${_(ALTERNAVITE_STRINGS.get("Please enter the new name for your CCX course.", "Please enter the new name for your CCX course."))}</p>
+
+%if ccx:
+  <form id="ccx-change-course-name-form" class="ccx-change-course-name-form" method="patch" data-remote="true" action="/api/ccx/v0/ccx/${ccx.locator}">
+    <input id="ccx-display-name" type="text" name="display_name" value="${ccx.display_name | n, js_escaped_string}" style="margin: 0.5em 0;"></input></br>
+    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_(ALTERNAVITE_STRINGS.get('Change CCX course name.', 'Change CCX course name.'))}">
+    <i class="fa fa-refresh fa-2x ccx-change-course-name-spinner" aria-hidden="true"></i>
+  </form>
+  <div class="ccx-change-course-name-feedback"></div>
+% endif
+
+<script>
+  $ccxChangeCourseNameForm = $("#ccx-change-course-name-form");
+  $ccxChangeCourseNameSpinner = $(".ccx-change-course-name-spinner");
+  $ccxChangeCourseNameFeedBack = $(".ccx-change-course-name-feedback");
+
+  $ccxChangeCourseNameForm.submit(function() {
+    $("input[type='submit']", this).attr("disabled", "disabled");
+    $ccxChangeCourseNameSpinner.css("display", "inline-block");
+  });
+
+  $ccxChangeCourseNameForm.on("ajax:complete", function() {
+    $("input[type='submit']", this).removeAttr("disabled");
+    $ccxChangeCourseNameSpinner.css("display", "none");
+    $ccxChangeCourseNameFeedBack.css("display", "block");
+  });
+
+  $ccxChangeCourseNameForm.on("ajax:success", function(event, data, status, xhr) {
+    $ccxChangeCourseNameFeedBack.text("${_(ALTERNAVITE_STRINGS.get('The CCX display name was successfully changed.', 'The CCX display name was successfully changed.'))}");
+  });
+
+  $ccxChangeCourseNameForm.on("ajax:error", function(event, xhr, status, error) {
+    if (xhr.getResponseHeader("Content-Type") === "text/html") {
+      $ccxChangeCourseNameFeedBack.text(error);
+    } else if (xhr.getResponseHeader("Content-Type") === "application/json") {
+      $ccxChangeCourseNameFeedBack.text(xhr.responseJSON.detail);
+    }
+  });
+</script>

--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_ccx-course-name.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_ccx-course-name.scss
@@ -1,0 +1,50 @@
+// Styles for lms/templates/ccx/course_name.html.
+
+.ccx-change-course-name-feedback {
+  display: none;
+  margin: 0.5em 0;
+}
+
+.ccx-change-course-name-spinner {
+  display: none;
+  -webkit-animation: ccx-spinner-loading-rotate 2s infinite linear; /* Safari 4+ */
+  -moz-animation: ccx-spinner-loading-rotate 2s infinite linear; /* Fx 5+ */
+  -o-animation: ccx-spinner-loading-rotate 2s infinite linear; /* Opera 12+ */
+  animation: ccx-spinner-loading-rotate 2s infinite linear; /* IE 10+, Fx 29+ */
+}
+
+@-webkit-keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+
+@-moz-keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+
+@-o-keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+
+@keyframes ccx-spinner-loading-rotate {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}

--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -12,6 +12,7 @@
 @import 'footer';
 @import 'course-experience';
 @import 'dashboard';
+@import 'ccx-course-name';
 
 
 //registration

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
@@ -67,6 +67,9 @@ from openedx.core.djangolib.js_utils import (
             <li class="nav-item">
               <button type="button" class="btn-link" data-section="grading_policy">${_("Grading Policy")}</button>
             </li>
+            <li class="nav-item">
+              <button type="button" class="btn-link" data-section="course_name">${_("Course Name")}</button>
+            </li>
           </ul>
           <section id="membership" class="idash-section" aria-label="${_('Batch Enrollment')}">
             <%include file="enrollment.html" args="" />
@@ -79,6 +82,9 @@ from openedx.core.djangolib.js_utils import (
           </section>
           <section id="grading_policy" class="idash-section" aria-label="${_('Grading Policy')}">
             <%include file="grading_policy.html" args="" />
+          </section>
+          <section id="course_name" class="idash-section" aria-label="${_('Course Name')}">
+            <%include file="course_name.html" args="" />
           </section>
           %endif
 

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/course_name.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/course_name.html
@@ -1,0 +1,52 @@
+<%page expression_filter="h"/>
+<%!
+  from django.utils.translation import ugettext as _
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+  from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+  )
+%>
+
+<%ALTERNAVITE_STRINGS = configuration_helpers.get_value('ALTERNAVITE_STRINGS', {})%>
+
+<h2 class="hd hd-2">${_(ALTERNAVITE_STRINGS.get("Change CCX course name.", "Change CCX course name."))}</h2>
+<hr>
+<p>${_(ALTERNAVITE_STRINGS.get("Please enter the new name for your CCX course.", "Please enter the new name for your CCX course."))}</p>
+
+%if ccx:
+  <form id="ccx-change-course-name-form" class="ccx-change-course-name-form" method="patch" data-remote="true" action="/api/ccx/v0/ccx/${ccx.locator}">
+    <input id="ccx-display-name" type="text" name="display_name" value="${ccx.display_name | n, js_escaped_string}" style="margin: 0.5em 0;"></input></br>
+    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_(ALTERNAVITE_STRINGS.get('Change CCX course name.', 'Change CCX course name.'))}">
+    <i class="fa fa-refresh fa-2x ccx-change-course-name-spinner" aria-hidden="true"></i>
+  </form>
+  <div class="ccx-change-course-name-feedback"></div>
+% endif
+
+<script>
+  $ccxChangeCourseNameForm = $("#ccx-change-course-name-form");
+  $ccxChangeCourseNameSpinner = $(".ccx-change-course-name-spinner");
+  $ccxChangeCourseNameFeedBack = $(".ccx-change-course-name-feedback");
+
+  $ccxChangeCourseNameForm.submit(function() {
+    $("input[type='submit']", this).attr("disabled", "disabled");
+    $ccxChangeCourseNameSpinner.css("display", "inline-block");
+  });
+
+  $ccxChangeCourseNameForm.on("ajax:complete", function() {
+    $("input[type='submit']", this).removeAttr("disabled");
+    $ccxChangeCourseNameSpinner.css("display", "none");
+    $ccxChangeCourseNameFeedBack.css("display", "block");
+  });
+
+  $ccxChangeCourseNameForm.on("ajax:success", function(event, data, status, xhr) {
+    $ccxChangeCourseNameFeedBack.text("${_(ALTERNAVITE_STRINGS.get('The CCX display name was successfully changed.', 'The CCX display name was successfully changed.'))}");
+  });
+
+  $ccxChangeCourseNameForm.on("ajax:error", function(event, xhr, status, error) {
+    if (xhr.getResponseHeader("Content-Type") === "text/html") {
+      $ccxChangeCourseNameFeedBack.text(error);
+    } else if (xhr.getResponseHeader("Content-Type") === "application/json") {
+      $ccxChangeCourseNameFeedBack.text(xhr.responseJSON.detail);
+    }
+  });
+</script>


### PR DESCRIPTION
## Description:

This PR adds a new feature to allow course staff users to change the CCX course name from the CCX instructor dashboard.

## Screenshot:

![image](https://user-images.githubusercontent.com/17520199/171520229-715e0be0-de88-4b3b-a095-32d38aedd667.png)

## Testing:

1. Enable 'CUSTOM_COURSES_EDX' in the LMS and CMS FEATURES list. Note: you will probably need to activate this feature in the lms.yml and studio.yml located in /edx/etc/.
2. Check out this branch and compile static assets. (paver update_assets or make static).
3. Go to Studio and create a new course.
4. Go to the course advanced settings and enable 'Enable CCX'.
5. Go to your dashboard and create a new CCX course from the previously created course (via CCX coach tab in the instructor dashboard).
6. Add your user as staff of the CCX main course (via instructor dashboard).
7. Go to the CCX Coach tab in the instructor dashboard.
8. You should now see a new tab called 'Course name'.
9. Fill in the form and check the result. 

## Note:

This feature has been considered for the following sites: certprepcourseware.pearson.com and certiportlearning.pearson.com

## Reviewers:

- [ ] @Jacatove 
- [ ] @anfbermudezme 