### PR TITLE
PADV-158 - Redirect to course_about according to is_ccx_admin.

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
@@ -24,8 +24,6 @@ from openedx.core.djangolib.js_utils import (
   <div class="instructor-dashboard-wrapper-2">
         <main id="main" aria-label="Content" tabindex="-1">
         <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content" aria-labelledby="header-ccx-dashboard">
-          <h2 class="hd hd-2" id="header-ccx-dashboard">${_("CCX Coach Dashboard")}</h2>
-
           %if not ccx:
             % if messages:
               <ul class="messages">
@@ -39,6 +37,7 @@ from openedx.core.djangolib.js_utils import (
               </ul>
             % endif
             % if is_ccx_admin:
+              <h2 class="hd hd-2" id="header-ccx-dashboard">${_("CCX Coach Dashboard")}</h2>
               <div>
                 <p class="request-response-error" id="ccx-create-message"></p>
                 <form action="${create_ccx_url}" class="ccx-form" method="POST" onsubmit="return validateForm(this)">
@@ -53,7 +52,10 @@ from openedx.core.djangolib.js_utils import (
                 </form>
               </div>
             % else:
-              <meta http-equiv='refresh' content='0; URL=about'>
+              <h2 class="hd hd-2" id="header-ccx-dashboard">
+                ${_("You are not an administrator to create CCX, you will be redirected to the Course About.")}
+              </h2>
+              <meta http-equiv='refresh' content='2; URL=about'>
             %endif
           %endif
 

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
@@ -38,19 +38,23 @@ from openedx.core.djangolib.js_utils import (
                 % endfor
               </ul>
             % endif
-            <div>
-              <p class="request-response-error" id="ccx-create-message"></p>
-              <form action="${create_ccx_url}" class="ccx-form" method="POST" onsubmit="return validateForm(this)">
-                <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
-                <div class="field">
-                  <label class="sr" for="ccx_name">${_('Name your CCX')}</label>
-                  <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
-                </div>
-                <div class="field">
-                  <button id="create-ccx" type="submit">${_('Create a new Custom Course')}</button>
-                </div>
-              </form>
-          </div>
+            % if is_ccx_admin:
+              <div>
+                <p class="request-response-error" id="ccx-create-message"></p>
+                <form action="${create_ccx_url}" class="ccx-form" method="POST" onsubmit="return validateForm(this)">
+                  <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
+                  <div class="field">
+                    <label class="sr" for="ccx_name">${_('Name your CCX')}</label>
+                    <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
+                  </div>
+                  <div class="field">
+                    <button id="create-ccx" type="submit">${_('Create a new Custom Course for edX')}</button>
+                  </div>
+                </form>
+              </div>
+            % else:
+              <meta http-equiv='refresh' content='0; URL=about'>
+            %endif
           %endif
 
           %if ccx:


### PR DESCRIPTION
In this PR is_ccx_admin is added, which comes from the edx-platform context [PADV-158 - edx-platform](https://github.com/Pearson-Advance/edx-platform/pull/76). When is_ccx_coach from the context is False or None the user will be redirected to course_about.

For the case where the user is an administrator, the ccx_coach tab is enabled

![admin](https://user-images.githubusercontent.com/30726391/181253569-043bd9a7-4b03-49c4-a93b-f3e68c565312.gif)

Otherwise, access to the ccx_coach tab is restricted so that ccx's cannot be created.

![edx](https://user-images.githubusercontent.com/30726391/181253558-d3023eff-ba4d-4f91-afbe-64421ea88adf.gif)

## PR's Related

### course-operations

[PADV-158 - course-operations](https://github.com/Pearson-Advance/course_operations/pull/105)

### edx-platform

[PADV-158 - edx-platform](https://github.com/Pearson-Advance/edx-platform/pull/76)

## Test this PR

To test this PR it is necessary to be in the correct branch of the related PR's and then enter
`http://localhost:18000/courses/{master_course}/ccx_coach`, do it for non-admin users and institution admins.