### PR TITLE
PAE-165.1: Fix incorrect variable name in _dashboard.scss.

### DIFF
--- a/edx-platform/pearson-regis-theme/lms/static/sass/partials/lms/theme/_dashboard.scss
+++ b/edx-platform/pearson-regis-theme/lms/static/sass/partials/lms/theme/_dashboard.scss
@@ -114,7 +114,7 @@ div.modal-content .modal-header button.close {
 
     &:hover,
     &:focus {
-      background: $red-6;
+      background: $red-60;
     }
   }
 }


### PR DESCRIPTION
## Description:

This PR adds a fix introduced on the branch pearson/PAE-165 that introduced a error on the file _dashboard.scss by incorrectly calling a color variable $red-60 on _variables.scss.

## Testing:

- Check out this branch.
- Enable Comprehensive theming: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html
- Compile assets, paver update_assets --themes=pearson-regis-theme
- Assign 'pearson-regis-theme' to a new site.

## Reviewers:

- [ ] @Squirrel18 