### PR TITLE
PADV-141 - feat: differentiate the message type.

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
@@ -86,11 +86,16 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         <h2 class="hd hd-2">${_("Student List Management")}</h2>
         %if messages:
           <label for="ccx_std_list_messages" class="sr">${_("CCX student list management response message")}</label>
-          <div id="ccx_std_list_messages" tabindex="-1" class="request-response-error">
+          <div id="ccx_std_list_messages" tabindex="-1" class="request-response">
             %for message in messages:
-              ${message}
+              <div class="msg msg-${message.tags}" style="margin: 0;">
+                <div class="msg-content">
+                  ${message}
+                </div>
+              </div>
             %endfor
           </div>
+        <br/>
         %endif
         <table>
           <thead>

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
@@ -86,11 +86,16 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         <h2 class="hd hd-2">${_("Student List Management")}</h2>
         %if messages:
           <label for="ccx_std_list_messages" class="sr">${_("CCX student list management response message")}</label>
-          <div id="ccx_std_list_messages" tabindex="-1" class="request-response-error">
+          <div id="ccx_std_list_messages" tabindex="-1" class="request-response">
             %for message in messages:
-              ${message}
+              <div class="msg msg-${message.tags}" style="margin: 0;">
+                <div class="msg-content">
+                  ${message}
+                </div>
+              </div>
             %endfor
           </div>
+        <br/>
         %endif
         <table>
           <thead>


### PR DESCRIPTION
## Description:

**Notes:**  This is the themes complementary PR of https://github.com/Pearson-Advance/edx-platform/pull/81. Therefore, this PR must be reviewed with the main PR.

Based on the current behavior, the enrollment section only shows error messages. Since https://github.com/Pearson-Advance/edx-platform/pull/81 is adding support for success messages as result of new Enrollments/Enrollments Allowed enrolled/invited by instructors, the changes this PR introduces are meant to differentiate both error and success messages.

