### PR TITLE
PADV-58-Vcertiport - Show enrollments and enrollments allowed in Student List Management.

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
@@ -116,6 +116,17 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
                 %endif
               </tr>
             %endfor
+            %for pending_enrollment in pending_ccx_members:
+              <tr>
+                <td>${'Pending Enrollment'}</td>
+                <td>${pending_enrollment.email}</td>
+                <td>
+                  <button type="button" class="revoke">
+                    <span class="fa fa-times-circle" aria-hidden="true"></span>${_("Revoke access")}
+                  </button>
+                </td>
+              </tr>
+            %endfor
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-58

## Description
 
This PR add pending_enrollments the context allowing to show both enrollments and enrollments allowed in the Student List Management in the CCX coach tab for certiport.

## PR's Related

### edx-platform

- https://github.com/Pearson-Advance/edx-platform/pull/80

### course_operations

- https://github.com/Pearson-Advance/course_operations/pull/116

## Type of Change

- [x] Show both enrollments and enrollments allowed in the Student List Management in the CCX coach tab for certiport.

## Testing

- Follow the testing instructions at https://github.com/Pearson-Advance/course_operations/pull/116

## Reviewers

- [x] @Jacatove 