### PR TITLE
PADV-194: Fix VUE/Certiport CCX coach enrollments.html template

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
@@ -3,19 +3,14 @@
 from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 %>
 
 <%
     allow_ccx_unenroll = True
 
-    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and not configuration_helpers.get_value('ALLOW_CCX_UNENROLL', True):
-        try:
-            from pearson_course_operation.utils import is_ccx_license_managed
-
-            allow_ccx_unenroll = not is_ccx_license_managed(course.id)
-        except ImportError:
-            pass
+    if run_extension_point('PCO_ENABLE_COURSE_LICENSING'):
+        allow_ccx_unenroll = not run_extension_point('PCO_IS_LICENSED_CCX', course_id=course.id)
 %>
 
 <h2 class="hd hd-2">${_("Enrollment")}</h2>
@@ -102,9 +97,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             <tr>
               <th class="label" scope="col">${_("Username")}</th>
               <th class="label" scope="col">${_("Email")}</th>
-              %if allow_ccx_unenroll:
-                <th class="label" scope="col">${_("Revoke access")}</th>
-              %endif
+              <th class="label" scope="col">${_("Revoke access")}</th>
             </tr>
           </thead>
           <tbody>

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
@@ -3,19 +3,14 @@
 from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 %>
 
 <%
     allow_ccx_unenroll = True
 
-    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and not configuration_helpers.get_value('ALLOW_CCX_UNENROLL', True):
-        try:
-            from pearson_course_operation.utils import is_ccx_license_managed
-
-            allow_ccx_unenroll = not is_ccx_license_managed(course.id)
-        except ImportError:
-            pass
+    if run_extension_point('PCO_ENABLE_COURSE_LICENSING'):
+        allow_ccx_unenroll = not run_extension_point('PCO_IS_LICENSED_CCX', course_id=course.id)
 %>
 
 <h2 class="hd hd-2">${_("Enrollment")}</h2>
@@ -102,9 +97,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             <tr>
               <th class="label" scope="col">${_("Username")}</th>
               <th class="label" scope="col">${_("Email")}</th>
-              %if allow_ccx_unenroll:
-                <th class="label" scope="col">${_("Revoke access")}</th>
-              %endif
+              <th class="label" scope="col">${_("Revoke access")}</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-194

## Description
 
This PR fixes a broken feature on **pearson-vue-theme** and **pearson-certiport-theme** themes, that allows to enable or disable the unenroll action on the "Enrollment" form on the CCX coach enrollment tab of any CCX course. Also, this PR includes a fix to the table header on the "Student List Management" table on the CCX coach enrollment tab, and an additional feature that displays a disabled "Revoke Access" button, with a hover title on any student on the "Student List Management" table with an active licensed enrollment.

## Type of Change

- [x] Remove unused imports or settings.
- [x] Determine unenroll condition with **PCO_IS_LICENSED_CCX** run_extension_point.
- [x] Fix "Student List Management" table header.
- [x] Add disabled "Revoke access" button to all students in the "Student List Management" table with an active licensed enrollment.

## Testing:

- Check out this branch.
- Enable Comprehensive theming: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html
- Compile assets: `paver update_assets --themes=pearson-certiport-theme,pearson-vue-theme`
- Assign **pearson-vue-theme** or **pearson-certiport-theme** to a course licensing enabled site.
- Login to an institution administrator account on the LMS.
- Go to the enrollment section in the CCX Coach tab on any licensed CCX.
- You shouldn't be able to unenroll any student using the "Enrollment" form.
- You shouldn't be able to use the "Revoke access" button on any student with an active licensed enrolment on the "Student List Management" section.
- Go to a CCX course on a site with course licensing disabled.
- You should be able to unenroll any student using the "Enrollment" form.
- You should be able to use the "Revoke access" button on any student in the "Student List Management" section.

## Reviewers

- [x] @Squirrel18
- [x] @alexjmpb  
- [x] @anfbermudezme 
- [x] @Jacatove 