### PR TITLE
PADV-185 - Removing Regis Log Out

### DIFF
--- a/ecommerce/regis/templates/edx/base_menu.html
+++ b/ecommerce/regis/templates/edx/base_menu.html
@@ -1,0 +1,7 @@
+{% load core_extras %}
+{% load i18n %}
+
+{% block additional_options %}
+{% endblock additional_options %}
+
+<li class="{{ additional_class }}"><a class="nav-link" href="{% url 'logout' %}">{% trans "Sign Out" as tmsg %}{{ tmsg | force_escape }}</a></li>

--- a/ecommerce/regis/templates/edx/base_menu.html
+++ b/ecommerce/regis/templates/edx/base_menu.html
@@ -3,5 +3,3 @@
 
 {% block additional_options %}
 {% endblock additional_options %}
-
-<li class="{{ additional_class }}"><a class="nav-link" href="{% url 'logout' %}">{% trans "Sign Out" as tmsg %}{{ tmsg | force_escape }}</a></li>

--- a/ecommerce/regis/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/regis/templates/edx/partials/_base_navbar.html
@@ -26,9 +26,6 @@
               <span class="sr-only">{% trans "Dashboard for:" as tmsg %}{{ tmsg | force_escape }}</span>
               {{ user.username }}
             </button>
-            <ul class="dropdown-menu" aria-expanded="false">
-              {% block dropdown_menu %}{% endblock dropdown_menu %}
-            </ul>
               {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
           </li>
         {% else %}

--- a/edx-platform/pearson-regis-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-regis-theme/lms/templates/header/user_dropdown.html
@@ -44,6 +44,5 @@ displayname = get_enterprise_learner_generic_name(request) or username
         % if configuration_helpers.get_value('EXTERNAL_SUPPORT_LINK', ''):
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${configuration_helpers.get_value('EXTERNAL_SUPPORT_LINK')}" target="_blank">${_("Support")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
     </div>
 </div>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-185

## Description
 
This PR removes the Sign Out button from both ecommerce and LMS in the Regis College theme.

## Type of Change

- [x] Remove Sign Out buttons.

## Testing:

- Check out this branch.
- Enable Comprehensive theming: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html
- Compile assets: `paver update_assets --themes=pearson-regis-theme`
- Apply **pearson-regis-theme** to a site and **regis** theme to the ecommerce.
- Verify there are not Sign Out buttons

## Reviewers

- [x] @kuipumu 
- [x] @Squirrel18 