### PR TITLE
PADV-237.1 Fixing typo on CERTPrep Homepage

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/index.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/index.html
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
     <img class="info-logo" src="${static.url('images/CertPREP_Logo.png')}">
     <div class="info">
       <h1 class="info-title">
-        ${_("Introducing the ultimate trianing solution")}
+        ${_("Introducing the ultimate training solution")}
       </h1>
       <p class="info-description">
         ${_("A comprehensive learning toolkit that saves trainers time and money.")}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-237

## Description
 
This small PR is intended to fix a typo on the CERTPrep homepage that was made on the previous PR for PADV-237.

## Type of Change

- [x] Fix typo on the homepage.

## Testing:

- Check out this branch.
- Enable Comprehensive theming: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html
- Compile assets: `paver update_assets --themes=pearson-vue-theme`
- Assign **pearson-vue-theme** to a new site.

## Reviewers

- [x] @kuipumu 
- [x] @anfbermudezme 