### PR TITLE
Pearson theme - Toggle Discover New tab in header

### DIFF
--- a/edx-platform/pearson-theme/lms/templates/header/navbar-authenticated.html
+++ b/edx-platform/pearson-theme/lms/templates/header/navbar-authenticated.html
@@ -44,7 +44,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         </div>
       % endif
     % endif
-    % if show_explore_courses:
+    % if show_explore_courses and configuration_helpers.get_value('SHOW_EXPLORE_COURSES', True):
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
           <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
              aria-current="${'page' if '/courses' in request.path else 'false'}">


### PR DESCRIPTION
## Description

This PR aims to solve a post migration issue reported (#78) in the [issues spreadsheet](https://pearsoneducationinc-my.sharepoint.com/:x:/g/personal/scott_dunn_pearson_com/EUIQBBqSeOBKs52ukuLyONUBQQ-7Zdff2NcjquZt3X6-SQ?e=bSiYRW). The issue consist in that the /courses page is showing all courses including those that are not desired to be shown, hence it's required to hide the Discover New tab to avoid users to access this page.

## Type of change

- [x] Make the visibility of the Discover New tab toggleable with the  SHOW_EXPLORE_COURSES site conf.

## How to test

- Checkout to this branch
- Enable comprehensive theming
- Compile themes
- Add the pearson-theme to a site
- Set the site configuration SHOW_EXPLORE_COURSES to true
- Notice that now the Discover New tab is not shown in the header

## Screenshots

![image](https://github.com/Pearson-Advance/openedx-themes/assets/62396424/a7827f61-5bd4-414a-a43b-1093a10c66e4)

## Reviewers

- [x] @ShonTitor  
- [ ] @Squirrel18 