### PR TITLE
Add custom settings site configurations in default theme

### DIFF
--- a/ecommerce/pearson-theme/templates/edx/checkout/receipt.html
+++ b/ecommerce/pearson-theme/templates/edx/checkout/receipt.html
@@ -118,15 +118,13 @@
         {% endif %}
       </div>
 
-      {% if show_receipt_cta_links %}
-        <div id="cta-nav-links" class="row">
-          <div class="col-xs-12 text-right">
-            <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
-              {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
-            </a>
-          </div>
+      <div id="cta-nav-links" class="row">
+        <div class="col-xs-12 text-right">
+          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
+            {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
+          </a>
         </div>
-      {% endif %}
+      </div>
     </div>
   </div>
 {% endblock content %}

--- a/ecommerce/pearson-theme/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/pearson-theme/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -1,0 +1,189 @@
+{% load i18n %}
+{% load django_markup %}
+{% load core_extras %}
+{% load currency_filters %}
+{% load purchase_info_tags %}
+{% load widget_tweaks %}
+
+{% if not is_bulk_purchase %}
+    {% include 'oscar/partials/alert_messages.html' %}
+{% endif %}
+
+<div id="content-inner">
+    {% block basket_form_main %}
+        <form action="." method="post">
+            {% csrf_token %}
+            {{ formset.management_form }}
+
+            {% for form, line_data in formset_lines_data %}
+                {% purchase_info_for_line request line_data.line as session %}
+                <div class="basket-items">
+                    {% if line_data.seat_type %}
+                        <p class="certificate_type">
+                            {% trans "Earn a valuable certificate to showcase the skills you learn in" as tmsg %}{{ tmsg | force_escape }}
+                        </p>
+                    {% endif %}
+                    <div class="row">
+                        <div class="col-md-2 col-sm-12 product-image">
+                            {{ form.id }}
+                            <img class="thumbnail" src="{{ line_data.image_url|default_if_none:'' }}"
+                                 alt="{{ line_data.product_title|default_if_none:'' }}"/>
+                        </div>
+                        <div class="col-md-5 col-sm-12">
+                            <p class="product-title">{{ line_data.product_title }} {% if line_data.course_key %}- {{ line_data.course_key.org }}
+                                ({{ line_data.course_key.run }}) {% endif %}</p>
+                            <p class="product-description">{{ line_data.product_description|default_if_none:'' }}</p>
+                        </div>
+                        {% if line_data.enrollment_code %}
+                            <div class="col-md-1 col-xs-12">
+                                <label class="product-price-label text-muted">{% trans 'Item Price' as tmsg %}{{ tmsg | force_escape }}</label>
+                                <span>{{ line_data.line.price_incl_tax|currency:line_data.line.price_currency }}</span>
+                            </div>
+                            <div class="col-md-3 col-xs-12 form-inline">
+                                <label class="product-price-label text-muted">{% trans 'Quantity' as tmsg %}{{ tmsg | force_escape }}</label>
+                                <div class="checkout-quantity form-group">
+                                    <div class="input-group spinner  {% if form.errors %}error{% endif %}">
+                                        {% render_field form.quantity class+="quantity form-control" min=min_seat_quantity %}
+                                        <div class="input-group-btn-vertical">
+                                            <button class="btn btn-primary" type="button">
+                                              <i class="fa fa-caret-up"></i>
+                                            </button>
+                                            <button class="btn btn-primary" type="button">
+                                              <i class="fa fa-caret-down"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <button class="btn btn-primary update-button" type="submit"
+                                            data-loading-text="{% trans 'Updating...' as tmsg %}{{ tmsg | force_escape }}">{% trans "Update" as tmsg %}{{ tmsg | force_escape }}</button>
+                                </div>
+                            </div>
+                        {% endif %}
+                        <div class="col-md-{% if line_data.enrollment_code %}1{% else %}5{% endif %} col-xs-12 product-prices pull-right">
+                            {% if line_data.enrollment_code %}
+                                <label class="product-price-label text-muted">{% trans 'Price' as tmsg %}{{ tmsg | force_escape }}</label>
+                            {% endif %}
+
+                            {% if line_data.line.has_discount %}
+                                <div class="discount">
+                                    <div class="benefit">
+                                        {% filter force_escape %}
+                                        {% blocktrans with benefit_value=line_data.benefit_value %}
+                                            {{ benefit_value }} off
+                                        {% endblocktrans %}
+                                        {% endfilter %}
+                                    </div>
+                                    <div class="old-price">
+                                        {{ line_data.line.line_price_incl_tax|currency:line_data.line.price_currency }}
+                                    </div>
+                                </div>
+                            {% endif %}
+                            <div class="price {% if line_data.line.has_discount %}discounted{% endif %}">
+                                {{ line_data.line.line_price_incl_tax_incl_discounts|currency:line_data.line.price_currency }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </form>
+    {% endblock %}
+
+    <div class="total">
+        <div class="row">
+            {% if show_voucher_form %}
+                {% block vouchers %}
+                    {% if basket.contains_a_voucher %}
+                        <div class="vouchers col-sm-7 col-xs-8">
+                            {% for voucher in basket.vouchers.all %}
+                                <p class="voucher">
+                                    {% filter force_escape %}
+                                        {% blocktrans with voucher_code=voucher.code %}
+                                            Coupon code {{ voucher_code }} applied
+                                        {% endblocktrans %}
+                                    {% endfilter %}
+                                <form action="{% url 'basket:vouchers-remove' pk=voucher.id %}" method="POST">
+                                    {% csrf_token %}
+                                    <button class="remove-voucher" type="submit"><i class="fa fa-times"></i>
+                                    </button>
+                                </form>
+                                </p>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {# Hide the entire section if a custom BasketView doesn't pass in a voucher form #}
+                        {% if voucher_form %}
+                            <div class="use-voucher col-sm-7 col-xs-8">
+                                <p id="voucher_form_link">
+                                    <a href="#voucher">{% trans "Apply a coupon code" as tmsg %}{{ tmsg | force_escape }}</a>
+                                </p>
+                                {% include 'oscar/basket/partials/add_voucher_form.html' %}
+                            </div>
+                        {% endif %}
+                    {% endif %}
+                {% endblock vouchers %}
+            {% endif %}
+
+            <div id="basket_totals" class="col-xs-4">
+                {% block order_total %}
+                    {% trans "Total:" as tmsg %}{{ tmsg | force_escape }}
+                    {{ order_total.incl_tax|currency:basket.currency }}
+                {% endblock %}
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            {# Switch Basket view in between single and bulk purchase items #}
+            {% if partner_sku %}
+                <div class="pull-left basket-switch-link">
+                    <a href="/basket/add/?sku={{ partner_sku }}" class="btn btn-link">
+                        {{ switch_link_text }}
+                    </a>
+                </div>
+            {% endif %}
+
+            <div class="pull-right payment-buttons" data-basket-id="{{ basket.id }}">
+                {% if free_basket %}
+                    <a href="{% url 'checkout:free-checkout' %}"
+                       data-track-type="click"
+                       data-track-event="edx.bi.ecommerce.basket.free_checkout"
+                       data-track-category="checkout"
+                       class="btn btn-success checkout-button">
+                        {% trans "Place Order" as tmsg %}{{ tmsg | force_escape }}
+                    </a>
+                {% else %}
+                    {% for processor in payment_processors %}
+                        <button data-track-type="click"
+                                data-track-event="edx.bi.ecommerce.basket.payment_selected"
+                                data-track-category="checkout"
+                                data-processor-name="{{ processor.NAME|lower }}"
+                                data-track-checkout-type="hosted"
+                                class="btn payment-button"
+                                id="{{ processor.NAME|lower }}">
+                            {% if processor.TITLE %}
+                                {% blocktrans with title=processor.TITLE %}Checkout with {{ title }}{% endblocktrans %}
+                            {% else %}
+                                {% trans "Checkout" as tmsg %}{{ tmsg | force_escape }}
+                            {% endif %}
+                        </button>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="row verification-note">
+        <div class="col-sm-12">
+            <span><i class="fa fa-exclamation-circle"></i></span>
+            {# Translators: <strong></strong> tags will bold the text within. Keep the tags and translate the text within. #}
+            {% trans "{strong_start}Note:{strong_end} To complete your enrollment, select Checkout or Checkout with PayPal." as tmsg %}
+            {% interpolate_html tmsg strong_start='<strong>'|safe strong_end='</strong>'|safe %}
+        </div>
+    </div>
+    <div class="row help">
+        <div class="col-sm-12">
+            <p><strong>{% trans "Have questions?" as tmsg %}{{ tmsg | force_escape }}</strong></p>
+            <a href="{{ support_url }}">{% trans "Please read our FAQs to view common questions about our certificates." as tmsg %}{{ tmsg | force_escape }}</a>
+        </div>
+    </div>
+</div>

--- a/ecommerce/pearson-theme/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/pearson-theme/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -9,6 +9,8 @@
     {% include 'oscar/partials/alert_messages.html' %}
 {% endif %}
 
+{% settings_value 'custom_settings' as custom_settings %}
+
 <div id="content-inner">
     {% block basket_form_main %}
         <form action="." method="post">
@@ -18,11 +20,6 @@
             {% for form, line_data in formset_lines_data %}
                 {% purchase_info_for_line request line_data.line as session %}
                 <div class="basket-items">
-                    {% if line_data.seat_type %}
-                        <p class="certificate_type">
-                            {% trans "Earn a valuable certificate to showcase the skills you learn in" as tmsg %}{{ tmsg | force_escape }}
-                        </p>
-                    {% endif %}
                     <div class="row">
                         <div class="col-md-2 col-sm-12 product-image">
                             {{ form.id }}
@@ -89,37 +86,40 @@
 
     <div class="total">
         <div class="row">
-            {% if show_voucher_form %}
-                {% block vouchers %}
-                    {% if basket.contains_a_voucher %}
-                        <div class="vouchers col-sm-7 col-xs-8">
-                            {% for voucher in basket.vouchers.all %}
-                                <p class="voucher">
-                                    {% filter force_escape %}
-                                        {% blocktrans with voucher_code=voucher.code %}
-                                            Coupon code {{ voucher_code }} applied
-                                        {% endblocktrans %}
-                                    {% endfilter %}
-                                <form action="{% url 'basket:vouchers-remove' pk=voucher.id %}" method="POST">
-                                    {% csrf_token %}
-                                    <button class="remove-voucher" type="submit"><i class="fa fa-times"></i>
-                                    </button>
-                                </form>
-                                </p>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        {# Hide the entire section if a custom BasketView doesn't pass in a voucher form #}
-                        {% if voucher_form %}
-                            <div class="use-voucher col-sm-7 col-xs-8">
-                                <p id="voucher_form_link">
-                                    <a href="#voucher">{% trans "Apply a coupon code" as tmsg %}{{ tmsg | force_escape }}</a>
-                                </p>
-                                {% include 'oscar/basket/partials/add_voucher_form.html' %}
+            {# If hide_voucher_section is set to True, it will hide the voucher section no matter what. #}
+            {% if not custom_settings.hide_voucher_section %}
+                {% if show_voucher_form %}
+                    {% block vouchers %}
+                        {% if basket.contains_a_voucher %}
+                            <div class="vouchers col-sm-7 col-xs-8">
+                                {% for voucher in basket.vouchers.all %}
+                                    <p class="voucher">
+                                        {% filter force_escape %}
+                                            {% blocktrans with voucher_code=voucher.code %}
+                                                Coupon code {{ voucher_code }} applied
+                                            {% endblocktrans %}
+                                        {% endfilter %}
+                                    <form action="{% url 'basket:vouchers-remove' pk=voucher.id %}" method="POST">
+                                        {% csrf_token %}
+                                        <button class="remove-voucher" type="submit"><i class="fa fa-times"></i>
+                                        </button>
+                                    </form>
+                                    </p>
+                                {% endfor %}
                             </div>
+                        {% else %}
+                            {# Hide the entire section if a custom BasketView doesn't pass in a voucher form #}
+                            {% if voucher_form %}
+                                <div class="use-voucher col-sm-7 col-xs-8">
+                                    <p id="voucher_form_link">
+                                        <a href="#voucher">{% trans "Promotional Code" as tmsg %}{{ tmsg | force_escape }}</a>
+                                    </p>
+                                    {% include 'oscar/basket/partials/add_voucher_form.html' %}
+                                </div>
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
-                {% endblock vouchers %}
+                    {% endblock vouchers %}
+                {% endif %}
             {% endif %}
 
             <div id="basket_totals" class="col-xs-4">
@@ -133,14 +133,19 @@
 
     <div class="row">
         <div class="col-sm-12">
-            {# Switch Basket view in between single and bulk purchase items #}
-            {% if partner_sku %}
-                <div class="pull-left basket-switch-link">
-                    <a href="/basket/add/?sku={{ partner_sku }}" class="btn btn-link">
-                        {{ switch_link_text }}
-                    </a>
-                </div>
-            {% endif %}
+            <div class="col-sm-12">
+                {# If hide_multiple_or_single_purchase_section is set to True, it will hide this section no matter what. #}
+                {% if not custom_settings.hide_multiple_or_single_purchase_section %}
+                    {# Switch Basket view in between single and bulk purchase items #}
+                    {% if partner_sku %}
+                        <div class="pull-left basket-switch-link">
+                            <a href="/basket/add/?sku={{ partner_sku }}" class="btn btn-link">
+                                {{ switch_link_text }}
+                            </a>
+                        </div>
+                    {% endif %}
+                {% endif %}
+            </div>
 
             <div class="pull-right payment-buttons" data-basket-id="{{ basket.id }}">
                 {% if free_basket %}
@@ -169,21 +174,6 @@
                     {% endfor %}
                 {% endif %}
             </div>
-        </div>
-    </div>
-
-    <div class="row verification-note">
-        <div class="col-sm-12">
-            <span><i class="fa fa-exclamation-circle"></i></span>
-            {# Translators: <strong></strong> tags will bold the text within. Keep the tags and translate the text within. #}
-            {% trans "{strong_start}Note:{strong_end} To complete your enrollment, select Checkout or Checkout with PayPal." as tmsg %}
-            {% interpolate_html tmsg strong_start='<strong>'|safe strong_end='</strong>'|safe %}
-        </div>
-    </div>
-    <div class="row help">
-        <div class="col-sm-12">
-            <p><strong>{% trans "Have questions?" as tmsg %}{{ tmsg | force_escape }}</strong></p>
-            <a href="{{ support_url }}">{% trans "Please read our FAQs to view common questions about our certificates." as tmsg %}{{ tmsg | force_escape }}</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

This PR adjusts some aesthetic requests, where the custom settings site configurations offered by ecommerce are activated to show or not elements.

![Selection_017](https://github.com/Pearson-Advance/openedx-themes/assets/30726391/7d946ad6-70a2-4675-8885-068677234fd6)

## Changes made

- [x] Add default template `hosted_checkout_basket`.
- [x] Add Custom Settings site configurations from ecommerce. 
- [x] Apply the aesthetic changes required. 
- [x] An unnecessary definition that prevented users from seeing the dashboard  link on the receipt page has been removed.

## How to test

- Run openedx services.
- Go to the basket page for a course in ecommerce.
- See the changes made.