### PR TITLE
PADV-998 - Show "Go to dashboard" link in the receipt pages.

### DIFF
--- a/ecommerce/aws/templates/edx/checkout/receipt.html
+++ b/ecommerce/aws/templates/edx/checkout/receipt.html
@@ -126,15 +126,13 @@
         {% endif %}
       </div>
 
-      {% if show_receipt_cta_links %}
-        <div id="cta-nav-links" class="row">
-          <div class="col-xs-12 text-right">
-            <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
-              {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
-            </a>
-          </div>
+      <div id="cta-nav-links" class="row">
+        <div class="col-xs-12 text-right">
+          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
+            {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
+          </a>
         </div>
-      {% endif %}
+      </div>
     </div>
   </div>
 {% endblock content %}

--- a/ecommerce/certprep/templates/edx/checkout/receipt.html
+++ b/ecommerce/certprep/templates/edx/checkout/receipt.html
@@ -118,15 +118,13 @@
         {% endif %}
       </div>
 
-      {% if show_receipt_cta_links %}
-        <div id="cta-nav-links" class="row">
-          <div class="col-xs-12 text-right">
-            <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
-              {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
-            </a>
-          </div>
+      <div id="cta-nav-links" class="row">
+        <div class="col-xs-12 text-right">
+          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
+            {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
+          </a>
         </div>
-      {% endif %}
+      </div>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Description:

This PR removes the Enterprise learner portal verification from the receipt pages so that the "Go to dashboard" link is always displayed.

## Screeenshots:
Certprep theme:
Before:
![image](https://github.com/Pearson-Advance/openedx-themes/assets/17520199/51206f8a-ae3e-41c0-b34e-b3a9dd02cb21)
After:
![image](https://github.com/Pearson-Advance/openedx-themes/assets/17520199/358ceec4-6e2c-4b3e-be1f-69cf4a4f9b9f)

AWS theme:
Before:
![image](https://github.com/Pearson-Advance/openedx-themes/assets/17520199/3bef0975-b370-4b63-b3c3-a83a48ca5cc9)
After:
![image](https://github.com/Pearson-Advance/openedx-themes/assets/17520199/03e2ab06-5d69-42eb-934a-a683f9bbc43d)

## How to test:
- Enable comprehensive themes for ecomemrce: https://edx-ecommerce.readthedocs.io/en/latest/theming.html
- Add a ecommerce site and set the certprep or aws theme.
- Purchase a product and go to the receipt page
- Check that the "Go to dashboard" link is displayed.

## Note:

Upon enabling Enterprise learner portal, we need to revisit this change.

## Reviewers:

- [ ] @alexjmpb 
- [ ] @AuraAlba 