### PR TITLE
PADV-1067 - CCX staff users should not be able to unenroll active enrollments

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/enrollment.html
@@ -65,7 +65,6 @@ from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
     %if allow_ccx_unenroll:
       <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
     %endif
-    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
   </div>
   <div class="request-response"></div>
   <div class="request-response-error"></div>

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/enrollment.html
@@ -65,7 +65,6 @@ from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
     %if allow_ccx_unenroll:
       <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
     %endif
-    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
   </div>
   <div class="request-response"></div>
   <div class="request-response-error"></div>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1067

## Description

This PR is a fix for a bug reported by the product owner, which is that the unenroll button was enable for all staff users, allowing them to enable seats as a conveniece. So it's a critical issue. The fix is remove one line where the logic is involved and doesn't make sense to have the line there.

## Changes made

- [x] Remove unnecesary line.

## How to test

- Run openedx installation with license enforcement
- Go to a ccx as an staff user
- The unenroll button should not appear.

### Before
![image](https://github.com/Pearson-Advance/openedx-themes/assets/30726391/92f8be60-72a3-4ad1-b291-435ae62e726e)

### After
![image](https://github.com/Pearson-Advance/openedx-themes/assets/30726391/f7539386-d95b-4449-b4a3-408ece3e857b)

