### PR TITLE
feat: disable ccx creation for Global Staff.

### DIFF
--- a/edx-platform/pearson-certiport-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/ccx/coach_dashboard.html
@@ -23,6 +23,7 @@ from openedx.core.djangolib.js_utils import (
 <section class="container">
   <div class="instructor-dashboard-wrapper-2">
         <main id="main" aria-label="Content" tabindex="-1">
+        %if not user.is_staff:
         <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content" aria-labelledby="header-ccx-dashboard">
           <h2 class="hd hd-2" id="header-ccx-dashboard">${_("CCX Coach Dashboard")}</h2>
 
@@ -89,6 +90,10 @@ from openedx.core.djangolib.js_utils import (
           %endif
 
       </section>
+      %endif
+      %if user.is_staff:
+      <h2 class="hd hd-2" id="header-ccx-dashboard">${_("Global Staff cannot create CCXs.")}</h2>
+      %endif
         </main>
   </div>
 </section>

--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
@@ -23,6 +23,7 @@ from openedx.core.djangolib.js_utils import (
 <section class="container">
   <div class="instructor-dashboard-wrapper-2">
         <main id="main" aria-label="Content" tabindex="-1">
+        %if not user.is_staff:
         <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content" aria-labelledby="header-ccx-dashboard">
           <h2 class="hd hd-2" id="header-ccx-dashboard">${_("CCX Coach Dashboard")}</h2>
 
@@ -89,6 +90,10 @@ from openedx.core.djangolib.js_utils import (
           %endif
 
       </section>
+      %endif
+      %if user.is_staff:
+      <h2 class="hd hd-2" id="header-ccx-dashboard">${_("Global Staff cannot create CCXs.")}</h2>
+      %endif
         </main>
   </div>
 </section>


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-1301

## Description

This PR disables the ability to create CCX for global staff users. 

### For Global Staff

![image](https://github.com/Pearson-Advance/openedx-themes/assets/30726391/ec012478-b3d8-42bf-b269-79492fe42fd4)

### For Institution Admin

![Selection_1344](https://github.com/Pearson-Advance/openedx-themes/assets/30726391/dbd19627-da99-4a63-90df-4cefc844eb4d)

## Changes made

- [x] Add the respective logic in the template for users.

## How to test

- Start openedx services with course operations
- Enable openedx-themes in edx-platform
- Go to the ccx_coach tab being global staff directly using the URL `http://localhost:18000/courses/{course_id}/ccx_coach`
- Go to the ccx_coach tab being Institution Admin
- The bahaviour should be the mentioned before