### PR TITLE
PADV-1532 - Change HTML tag in Certprep index page.

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_extras.scss
@@ -359,7 +359,7 @@ iframe.rocket-chat-view {
       overflow: auto;
       flex-direction: row;
 
-      button {
+      a {
         border: none;
         font-weight: 500;
         font-size: 12px;

--- a/edx-platform/pearson-vue-theme/lms/templates/index.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/index.html
@@ -22,11 +22,11 @@ from django.utils.translation import ugettext as _
     <section class="buttons-section-container">
       <div class="buttons-section-signin-container">
         <p>${_("Access my course.")}</p>
-        <button class="btn btn-primary" href="/login" role="button">${_("Log in Here")}</button>
+        <a class="btn btn-primary" href="/login" role="button">${_("Log in Here")}</a>
       </div>
       <div class="buttons-section-catalog-container">
         <p>${_("Looking for online IT training? See the CertPREP by Pearson course catalog.")}</p>
-        <button class="btn btn-primary" href="https://www.mindhubpro.com/shop/courseware" role="button" target="_blank">${_("View All Courses")}</button>
+        <a class="btn btn-primary" href="https://www.mindhubpro.com/shop/courseware" role="button" target="_blank">${_("View All Courses")}</a>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Description:

This PR fixes the tag of the buttons in the CertPrep landing page.

## Screenshot:

**There are no visual changes**

![image](https://github.com/user-attachments/assets/41a8d8b4-372b-4bd6-96f0-3f7b48c1ae80)

## Note:

PR related: https://github.com/Pearson-Advance/openedx-themes/pull/257

## Reviewers:

- [ ] @AuraAlba 