### PR TITLE
PADV-1690 - Remove price references in the checkout page for default theme.

### DIFF
--- a/ecommerce/pearson-theme/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/pearson-theme/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -55,29 +55,6 @@
                                 </div>
                             </div>
                         {% endif %}
-                        <div class="col-md-{% if line_data.enrollment_code %}1{% else %}5{% endif %} col-xs-12 product-prices pull-right">
-                            {% if line_data.enrollment_code %}
-                                <label class="product-price-label text-muted">{% trans 'Price' as tmsg %}{{ tmsg | force_escape }}</label>
-                            {% endif %}
-
-                            {% if line_data.line.has_discount %}
-                                <div class="discount">
-                                    <div class="benefit">
-                                        {% filter force_escape %}
-                                        {% blocktrans with benefit_value=line_data.benefit_value %}
-                                            {{ benefit_value }} off
-                                        {% endblocktrans %}
-                                        {% endfilter %}
-                                    </div>
-                                    <div class="old-price">
-                                        {{ line_data.line.line_price_incl_tax|currency:line_data.line.price_currency }}
-                                    </div>
-                                </div>
-                            {% endif %}
-                            <div class="price {% if line_data.line.has_discount %}discounted{% endif %}">
-                                {{ line_data.line.line_price_incl_tax_incl_discounts|currency:line_data.line.price_currency }}
-                            </div>
-                        </div>
                     </div>
                 </div>
             {% endfor %}
@@ -121,13 +98,6 @@
                     {% endblock vouchers %}
                 {% endif %}
             {% endif %}
-
-            <div id="basket_totals" class="col-xs-4">
-                {% block order_total %}
-                    {% trans "Total:" as tmsg %}{{ tmsg | force_escape }}
-                    {{ order_total.incl_tax|currency:basket.currency }}
-                {% endblock %}
-            </div>
         </div>
     </div>
 
@@ -154,7 +124,7 @@
                        data-track-event="edx.bi.ecommerce.basket.free_checkout"
                        data-track-category="checkout"
                        class="btn btn-success checkout-button">
-                        {% trans "Place Order" as tmsg %}{{ tmsg | force_escape }}
+                        {% trans "Enroll" as tmsg %}{{ tmsg | force_escape }}
                     </a>
                 {% else %}
                     {% for processor in payment_processors %}


### PR DESCRIPTION
## Description:

This PR removes the price references in the pearson-theme checkout page.

## Screenshot:

**Before:**
![image](https://github.com/user-attachments/assets/08772781-63fd-449a-8afc-6ab6e0179a5b)

**After:**
![image](https://github.com/user-attachments/assets/bb2fdc44-c996-40c3-9627-476922767b3a)

## Note:

It's important to set these settings in the ecommerce site configuration (custom settings) to replicate the behavior:

`{
    "hide_multiple_or_single_purchase_section": true,
    "hide_voucher_section": true
}`

## Reviewers:

- [ ] @AuraAlba 