### PR TITLE
PADV-1689 Change label for external id field into Amazon site's Registration Form

### DIFF
--- a/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
+++ b/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
@@ -1,0 +1,73 @@
+<div class="js-form-feedback" aria-live="assertive" tabindex="-1">
+</div>
+
+<% if (!context.syncLearnerProfileData) { %>
+	<div class="toggle-form">
+		<span class="text"><%- edx.StringUtils.interpolate(gettext('Already have an {platformName} account?'), {platformName: context.platformName }) %></span>
+		<a href="#login" class="form-toggle" data-type="login"><%- gettext("Sign in.") %></a>
+	</div>
+<% } %>
+
+<form id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
+
+    <% if (!context.currentProvider) { %>
+        <% if (context.providers.length > 0 || context.hasSecondaryProviders) { %>
+            <div class="login-providers">
+                <div class="section-title lines">
+                    <h3>
+                        <span class="text"><%- gettext("Create an account using") %></span>
+                    </h3>
+                </div>
+                <%
+                _.each( context.providers, function( provider) {
+                    if ( provider.registerUrl ) { %>
+                        <button type="button" class="button button-primary button-<%- provider.id %> login-provider register-<%- provider.id %>" data-provider-url="<%- provider.registerUrl %>">
+                            <div class="icon <% if ( provider.iconClass ) { %>fa <%- provider.iconClass %><% } %>" aria-hidden="true">
+                                <% if ( provider.iconImage ) { %>
+                                    <img class="icon-image" src="<%- provider.iconImage %>" alt="<%- provider.name %> icon" />
+                                <% } %>
+                            </div>
+                            <span aria-hidden="true"><%- provider.name %></span>
+                            <span class="sr"><%- _.sprintf( gettext("Create account using %(providerName)s."), {providerName: provider.name} ) %></span>
+                        </button>
+                <%  }
+                }); %>
+
+                <% if ( context.hasSecondaryProviders ) { %>
+                    <button type="button" class="button-secondary-login form-toggle" data-type="institution_login">
+                        <%- gettext("Use my institution/campus credentials") %>
+                    </button>
+                <% } %>
+            </div>
+            <% if (!context.is_require_third_party_auth_enabled) { %>
+                <div class="section-title lines">
+                    <h3>
+                        <span class="text"><%- gettext("or create a new one here") %></span>
+                    </h3>
+                </div>
+            <% } %>
+        <% } else if (!context.is_require_third_party_auth_enabled) { %>
+            <h1 class="section-title"><%- gettext('Create an Account')%></h1>
+        <% } %>
+    <% } else if (context.autoRegisterWelcomeMessage) { %>
+        <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>
+    <% } %>
+
+    <div class="form-fields <% if (context.is_require_third_party_auth_enabled) { %>hidden<% } %>">
+        <%= context.fields /* xss-lint: disable=underscore-not-escaped */ %>
+
+        <div class="form-field checkbox-optional_fields_toggle">
+            <input type="checkbox" id="toggle_optional_fields" class="input-block checkbox"">
+            <label for="toggle_optional_fields">
+                <span class="label-text-small">
+                    <%- gettext("Support education research by providing additional information") %>
+                </span>
+            </label>
+        </div>
+
+
+        <button type="submit" class="action action-primary action-update js-register register-button">
+            <% if ( context.registerFormSubmitButtonText ) { %><%- context.registerFormSubmitButtonText %><% } else { %><%- gettext("Create Account") %><% } %>
+        </button>
+    </div>
+</form>

--- a/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
+++ b/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
@@ -71,3 +71,7 @@
         </button>
     </div>
 </form>
+<script>
+    const fullname_field_label = document.querySelector('label[for="register-name"]');
+    fullname_field_label.textContent = "Company Name"
+</script>


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1689

## Description
Change label for "fullname" to "Company name" of the registration form through a new theme that would be applied to the Amazon site with a custom JS script

## Changes Made

- [x] Create pearson-amzn-theme
- [x] Edit registration template to add a custom JS

## How To Test

1. Follow [Openedx documentation](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html#) for applying themes to a site and set "pearson-amzn-theme" to the desire site. 
2. Strongly recommend to [compile the assets](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/compiling_theme.html#id2) into the LMS prior to testing, then restart the lms dev-container. 
3. Thru a incognito session, go to LMS registration page and confirms the first label is named "Company Name" as per the image below. Registration shall work as usual this is just a cosmetic change.

![image](https://github.com/user-attachments/assets/1e3caa5a-5223-4054-93e9-a839cc1988f3)
