### PR TITLE
PADV-1964: Disable LMS CCX creation and CCX coach tabs

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html
@@ -2,6 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%!
+import waffle
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import (
@@ -22,79 +23,70 @@ from openedx.core.djangolib.js_utils import (
 
 <section class="container">
   <div class="instructor-dashboard-wrapper-2">
-        <main id="main" aria-label="Content" tabindex="-1">
-        %if not user.is_staff:
-        <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content" aria-labelledby="header-ccx-dashboard">
-          <h2 class="hd hd-2" id="header-ccx-dashboard">${_("CCX Coach Dashboard")}</h2>
+    <main id="main" aria-label="Content" tabindex="-1">
+      <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content" aria-labelledby="header-ccx-dashboard">
+        %if ccx:
+        <h2 class="hd hd-2" id="header-ccx-dashboard">${_("CCX Coach Dashboard")}</h2>
 
-          %if not ccx:
-            % if messages:
-              <ul class="messages">
-                % for message in messages:
-                  % if message.tags:
-                    <li class="${message.tags}">${message}</li>
-                  % else:
-                    <li>${message}</li>
-                  % endif
-                % endfor
-              </ul>
-            % endif
-            <div>
-              <p class="request-response-error" id="ccx-create-message"></p>
-              <form action="${create_ccx_url}" class="ccx-form" method="POST" onsubmit="return validateForm(this)">
-                <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
-                <div class="field">
-                  <label class="sr" for="ccx_name">${_('Name your CCX')}</label>
-                  <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
-                </div>
-                <div class="field">
-                  <button id="create-ccx" type="submit">${_('Create a new Custom Course')}</button>
-                </div>
-              </form>
-          </div>
-          %endif
+        <ul class="instructor-nav">
+          % if waffle.switch_is_active('enable_ccx_coach_dashboard_membership_tab'):
+          <li class="nav-item">
+            <button type="button" class="btn-link" data-section="membership">${_("Enrollment")}</button>
+          </li>
+          % endif
+          % if waffle.switch_is_active('enable_ccx_coach_dashboard_schedule_tab'):
+          <li class="nav-item">
+            <button type="button" class="btn-link" data-section="schedule">${_("Schedule")}</button>
+          </li>
+          % endif
+          % if waffle.switch_is_active('enable_ccx_coach_dashboard_student_admin_tab'):
+          <li class="nav-item">
+            <button type="button" class="btn-link" data-section="student_admin">${_("Student Admin")}</button>
+          </li>
+          % endif
+          % if waffle.switch_is_active('enable_ccx_coach_dashboard_grading_policy_tab'):
+          <li class="nav-item">
+            <button type="button" class="btn-link" data-section="grading_policy">${_("Grading Policy")}</button>
+          </li>
+          % endif
+          % if waffle.switch_is_active('enable_ccx_coach_dashboard_course_name_tab'):
+          <li class="nav-item">
+            <button type="button" class="btn-link" data-section="course_name">${_("Course Name")}</button>
+          </li>
+          % endif
+        </ul>
 
-          %if ccx:
-          <ul class="instructor-nav">
-            <li class="nav-item">
-              <button type="button" class="btn-link" data-section="membership">${_("Enrollment")}</button>
-            </li>
-            <li class="nav-item">
-              <button type="button" class="btn-link" data-section="schedule">${_("Schedule")}</button>
-            </li>
-            <li class="nav-item">
-              <button type="button" class="btn-link" data-section="student_admin">${_("Student Admin")}</button>
-            </li>
-            <li class="nav-item">
-              <button type="button" class="btn-link" data-section="grading_policy">${_("Grading Policy")}</button>
-            </li>
-            <li class="nav-item">
-              <button type="button" class="btn-link" data-section="course_name">${_("Course Name")}</button>
-            </li>
-          </ul>
-          <section id="membership" class="idash-section" aria-label="${_('Batch Enrollment')}">
-            <%include file="enrollment.html" args="" />
-          </section>
-          <section id="schedule" class="idash-section" aria-label="${_('Schedule')}">
-            <%include file="schedule.html" args="" />
-          </section>
-          <section id="student_admin" class="idash-section" aria-label="${_('Student Grades')}">
-            <%include file="student_admin.html" args="" />
-          </section>
-          <section id="grading_policy" class="idash-section" aria-label="${_('Grading Policy')}">
-            <%include file="grading_policy.html" args="" />
-          </section>
-          <section id="course_name" class="idash-section" aria-label="${_('Course Name')}">
-            <%include file="course_name.html" args="" />
-          </section>
-          %endif
+        % if waffle.switch_is_active('enable_ccx_coach_dashboard_membership_tab'):
+        <section id="membership" class="idash-section" aria-label="${_('Batch Enrollment')}">
+          <%include file="enrollment.html" args="" />
+        </section>
+        %endif
+        % if waffle.switch_is_active('enable_ccx_coach_dashboard_schedule_tab'):
+        <section id="schedule" class="idash-section" aria-label="${_('Schedule')}">
+          <%include file="schedule.html" args="" />
+        </section>
+        %endif
+        % if waffle.switch_is_active('enable_ccx_coach_dashboard_student_admin_tab'):
+        <section id="student_admin" class="idash-section" aria-label="${_('Student Grades')}">
+          <%include file="student_admin.html" args="" />
+        </section>
+        %endif
+        % if waffle.switch_is_active('enable_ccx_coach_dashboard_grading_policy_tab'):
+        <section id="grading_policy" class="idash-section" aria-label="${_('Grading Policy')}">
+          <%include file="grading_policy.html" args="" />
+        </section>
+        %endif
+        % if waffle.switch_is_active('enable_ccx_coach_dashboard_course_name_tab'):
+        <section id="course_name" class="idash-section" aria-label="${_('Course Name')}">
+          <%include file="course_name.html" args="" />
+        </section>
+        %endif
 
+        %else:
+        <h2 class="hd hd-2" id="header-ccx-dashboard">${_("Cannot create CCXs.")}</h2>
+        %endif
       </section>
-      %endif
-      %if user.is_staff:
-      <h2 class="hd hd-2" id="header-ccx-dashboard">${_("Global Staff cannot create CCXs.")}</h2>
-      %endif
-        </main>
+    </main>
   </div>
 </section>
 


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1964

## Description

This PR disables the CCX coach tab creation form, this allow us to disable CCX creation from the LMS from any user, additionally all CCX coach tabs can be hidden/shown using a waffle switch for each one, we have decided to do this instead of removing all of them since it's not clear which tabs we want to disable or keep in the future.

## Type of Change

- [x] Modified `edx-platform/pearson-vue-theme/lms/templates/ccx/coach_dashboard.html` template.

## Testing:

1. Enable comprehensive theming on your Open edX platform.
2. Set the theme to your testing site to "pearson-vue-theme".
3. Setup CCX on a course and add a CCX coach to the course.
4. Login has the CCX coach.
5. Go to a course CCX coach tab.
6. The tab should show an empty page blocking the user from creating a CCX.
7. Enable these waffle switches:

```
enable_ccx_coach_dashboard_membership_tab
enable_ccx_coach_dashboard_schedule_tab
enable_ccx_coach_dashboard_student_admin_tab
enable_ccx_coach_dashboard_grading_policy_tab
enable_ccx_coach_dashboard_course_name_tab
```

9. Go to an existing CCX.
10. Go to the CCX coach tab.
11. All tabs on the CCX coach tab should be enabled.
12. Disable the previously created switches.
13. Go to the CCX coach tab.
14. All tabs on the CCX coach tab should be disabled.
