### PR TITLE
feat: update header text

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/header/navbar-authenticated.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import gettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             Pearson ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>


### PR DESCRIPTION
# Description



This PR resolves [PADV-1998](https://agile-jira.pearson.com/browse/PADV-1998)

## Change log
- Added header template to override "Courses" link text for "Pearson Courses".

### Visual results
#### Before
![2025-02-07_16-14](https://github.com/user-attachments/assets/2f7d6122-c841-470b-80b2-715936db27ac)


#### After
![bbb](https://github.com/user-attachments/assets/cae5278b-0544-4214-af9d-e839eeaaf06b)


### How to test
Go to `devstack` folder and open the lms shell
```bash 
make lms-shell 
```
Inside of the shell, move to
```bash 
/edx/etc/
```

Then open the file `lms.yml`
```bash 
# /edx/etc/
vim lms.yml
```

Find the option `ENABLE_COMPREHENSIVE_THEMING` and set it in `true`
```bash
 ENABLE_COMPREHENSIVE_THEMING: true
``` 
Find the option `COMPREHENSIVE_THEME_DIRS` and fill it with
```shell
COMPREHENSIVE_THEME_DIRS:
- '/edx/app/edx-themes/edx-platform'
``` 
Save the file and exit from vim ( if you're using it ) do not close the terminal, it will be useful soon. After that, go to http://localhost:18000/admin/theming/sitetheme/ and configure the site `http://localhost:18000/`, fill the input `Theme dir name` with the value `pearson-vue-theme` and save.

Go back to lms terminal and run this command, this could take a few minutes to complete
```shell
cd /edx/app/edxapp/edx-platform ; paver update_assets lms
``` 

Finally, restart the lms
```shell
make lms-restart
``` 

And that's it, you should be able to [see](http://localhost:18000/dashboard) the theming along with the changes in the header.

