### PR TITLE
feat: user profile name in user_dropdown template

### DIFF
--- a/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
@@ -1,0 +1,59 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
+%>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(self.real_user)
+displayname = get_enterprise_learner_generic_name(request) or username
+enterprise_customer_portal = get_enterprise_learner_portal(request)
+## Enterprises with the learner portal enabled should not show order history, as it does
+## not apply to the learner's method of purchasing content.
+should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+%>
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <img data-hj-suppress class="user-image-frame" src="${profile_image_url}" alt="">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span data-hj-suppress class="username">${displayname}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        % if not enterprise_customer_portal:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        % else:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
+        % endif
+
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        % if should_show_order_history:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>

--- a/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-aws-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-aws-theme/lms/templates/header/user_dropdown.html
@@ -22,7 +22,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
@@ -1,0 +1,59 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
+%>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(self.real_user)
+displayname = get_enterprise_learner_generic_name(request) or username
+enterprise_customer_portal = get_enterprise_learner_portal(request)
+## Enterprises with the learner portal enabled should not show order history, as it does
+## not apply to the learner's method of purchasing content.
+should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+%>
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <img data-hj-suppress class="user-image-frame" src="${profile_image_url}" alt="">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span data-hj-suppress class="username">${displayname}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        % if not enterprise_customer_portal:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        % else:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
+        % endif
+
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        % if should_show_order_history:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>

--- a/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
@@ -1,0 +1,59 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
+%>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(self.real_user)
+displayname = get_enterprise_learner_generic_name(request) or username
+enterprise_customer_portal = get_enterprise_learner_portal(request)
+## Enterprises with the learner portal enabled should not show order history, as it does
+## not apply to the learner's method of purchasing content.
+should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+%>
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <img data-hj-suppress class="user-image-frame" src="${profile_image_url}" alt="">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span data-hj-suppress class="username">${displayname}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        % if not enterprise_customer_portal:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        % else:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
+        % endif
+
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        % if should_show_order_history:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>

--- a/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
@@ -1,0 +1,59 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
+%>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(self.real_user)
+displayname = get_enterprise_learner_generic_name(request) or username
+enterprise_customer_portal = get_enterprise_learner_portal(request)
+## Enterprises with the learner portal enabled should not show order history, as it does
+## not apply to the learner's method of purchasing content.
+should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+%>
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <img data-hj-suppress class="user-image-frame" src="${profile_image_url}" alt="">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span data-hj-suppress class="username">${displayname}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        % if not enterprise_customer_portal:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        % else:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
+        % endif
+
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        % if should_show_order_history:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>

--- a/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
@@ -1,0 +1,59 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+<%!
+import json
+
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
+%>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(self.real_user)
+displayname = get_enterprise_learner_generic_name(request) or username
+enterprise_customer_portal = get_enterprise_learner_portal(request)
+## Enterprises with the learner portal enabled should not show order history, as it does
+## not apply to the learner's method of purchasing content.
+should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+%>
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <img data-hj-suppress class="user-image-frame" src="${profile_image_url}" alt="">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span data-hj-suppress class="username">${displayname}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        % if not enterprise_customer_portal:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        % else:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
+        % endif
+
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        % if should_show_order_history:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>

--- a/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.


### PR DESCRIPTION
# Description

This PR adds the user's full name and includes the necessary templates to override the platform's base styles. If the user does not have a full name, the default value used will be the `username`.  

This change applies to all relevant themes of the application.  

For testing instructions, please refer to PR #263, where you will find a detailed list of steps to test this change.  

## Change log
- Added full name support for users, with "username" as the fallback.
- Implemented templates to override base platform styles.
- Applied changes across all relevant themes.

### How to test
Refer to PR #263 for detailed testing steps.