### PR TITLE
PADV-2086 Rename username register field for Amazon theme

### DIFF
--- a/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
+++ b/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
@@ -72,6 +72,11 @@
     </div>
 </form>
 <script>
-    const fullname_field_label = document.querySelector('label[for="register-name"]');
-    fullname_field_label.textContent = "Company Name"
+    const fullname_field_label = document.querySelector('label[for="register-name"] > .label-text');
+    const username_field_label = document.querySelector('label[for="register-username"] > .label-text');
+    const username_desc = document.getElementById('register-username-desc');
+
+    fullname_field_label.textContent = fullname_field_label.textContent.replace('Full Name', 'Company Name');
+    username_field_label.textContent = username_field_label.textContent.replace('Public Username', 'External ID');
+    username_desc.textContent = username_desc.textContent.replace('The name that will identify', 'This ID will identify');
 </script>

--- a/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
+++ b/edx-platform/pearson-amazon-theme/lms/templates/student_account/register.underscore
@@ -71,12 +71,15 @@
         </button>
     </div>
 </form>
-<script>
+<script type="text/javascript">
     const fullname_field_label = document.querySelector('label[for="register-name"] > .label-text');
     const username_field_label = document.querySelector('label[for="register-username"] > .label-text');
     const username_desc = document.getElementById('register-username-desc');
 
-    fullname_field_label.textContent = fullname_field_label.textContent.replace('Full Name', 'Company Name');
-    username_field_label.textContent = username_field_label.textContent.replace('Public Username', 'External ID');
-    username_desc.textContent = username_desc.textContent.replace('The name that will identify', 'This ID will identify');
+    fullname_field_label.textContent = fullname_field_label.textContent.replace('Full Name', gettext('Company Name'));
+    username_field_label.textContent = username_field_label.textContent.replace('Public Username', gettext('External ID'));
+    username_desc.textContent = username_desc.textContent.replace(
+        'The name that will identify you in your courses. It cannot be changed later.',
+        gettext('This ID will identify you in your courses. It cannot be changed later.')
+    );
 </script>


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2086

## Description

Changes the label of the username field into the registration form. 

## Changes Made

[x] Changes the label of the username field into the registration form vie JS. 

## How To Test

Enable this theme on your site, go into the registration form and confirm that there's no visible "username" field, instead it shall look like this

![image](https://github.com/user-attachments/assets/7449f1ea-90f5-4a9a-ae27-5e5ff412c526)


