### PR TITLE
PADV-2042 feat: add capability to add link in banner message

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
@@ -17,6 +17,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
+from xmodule.capa.util import sanitize_html
 
 from common.djangoapps.student.models import CourseEnrollment
 %>
@@ -24,6 +25,10 @@ from common.djangoapps.student.models import CourseEnrollment
 <%
   cert_name_short = settings.CERT_NAME_SHORT
   cert_name_long = settings.CERT_NAME_LONG
+  maintenance_banner_text = configuration_helpers.get_value(
+    'MAINTENANCE_BANNER_TEXT',
+    settings.MAINTENANCE_BANNER_TEXT
+  )
 %>
 
 
@@ -112,6 +117,7 @@ from common.djangoapps.student.models import CourseEnrollment
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">
+  %if maintenance_banner_text:
     <div class="page-banner">
         <div class="user-messages" role="complementary" aria-label="messages">
             <ul class="user-messages-ul">
@@ -119,13 +125,14 @@ from common.djangoapps.student.models import CourseEnrollment
                         <div class="alert alert-warning" role="alert">
                             <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
                             <p class="lh-lg">
-                                CertPREP is getting a new name! In addition to the change you can see in our banner, you'll continue to see ongoing changes in our courseware and communications over the few months as we transition to our new "Pearson Skilling Suite" name.
+                                ${sanitize_html(maintenance_banner_text) | n, decode.utf8}
                             </p>
                         </div>
                     </li>
             </ul>
         </div>
     </div>
+    %endif
     %if banner_account_activation_message:
         <div class="dashboard-banner">
             ${banner_account_activation_message | n, decode.utf8}


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2042

### Description
Add capability for html tags in text banner

### Changes made
Get banner message from site configuration
Add sanitize html function to avoid danger tags as script

### Screenshots
![Screenshot from 2025-03-14 17-22-44](https://github.com/user-attachments/assets/5d4a0b8c-7d7e-467c-bed4-57530ce1765a)

### How to test
Go to devstack folder and open the lms shell

`make lms-shell `
Inside of the shell, move to

`/edx/etc/`
Then open the file lms.yml

```
# /edx/etc/
vim lms.yml
```
Find the option ENABLE_COMPREHENSIVE_THEMING and set it in true

` ENABLE_COMPREHENSIVE_THEMING: true`
Find the option COMPREHENSIVE_THEME_DIRS and fill it with

```
COMPREHENSIVE_THEME_DIRS:
- '/edx/app/edx-themes/edx-platform'
```
Save the file and exit from vim ( if you're using it ) do not close the terminal, it will be useful soon. After that, go to http://localhost:18000/admin/theming/sitetheme/ and configure the site http://localhost:18000/, fill the input Theme dir name with the value pearson-vue-theme and save.

Go back to lms terminal and run this command, this could take a few minutes to complete

`cd /edx/app/edxapp/edx-platform ; paver update_assets lms`
Finally, restart the lms

`make lms-restart`
And that's it, you should be able to [see](http://localhost:18000/dashboard) the theming along with the changes in the banner.