### PR TITLE
fix: remove default value

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
@@ -26,8 +26,7 @@ from common.djangoapps.student.models import CourseEnrollment
   cert_name_short = settings.CERT_NAME_SHORT
   cert_name_long = settings.CERT_NAME_LONG
   maintenance_banner_text = configuration_helpers.get_value(
-    'MAINTENANCE_BANNER_TEXT',
-    settings.MAINTENANCE_BANNER_TEXT
+    'MAINTENANCE_BANNER_TEXT'
   )
 %>
 


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2042

### Description
Remove default value to only show banner message when is configured in site configurations

### How to test
Go to devstack folder and open the lms shell

`make lms-shell `
Inside of the shell, move to

`/edx/etc/`
Then open the file lms.yml

```
# /edx/etc/
vim lms.yml
```
Find the option ENABLE_COMPREHENSIVE_THEMING and set it in true

` ENABLE_COMPREHENSIVE_THEMING: true`
Find the option COMPREHENSIVE_THEME_DIRS and fill it with

```
COMPREHENSIVE_THEME_DIRS:
- '/edx/app/edx-themes/edx-platform'
```
Save the file and exit from vim ( if you're using it ) do not close the terminal, it will be useful soon. After that, go to http://localhost:18000/admin/theming/sitetheme/ and configure the site http://localhost:18000/, fill the input Theme dir name with the value pearson-vue-theme and save.

Go back to lms terminal and run this command, this could take a few minutes to complete

`cd /edx/app/edxapp/edx-platform ; paver update_assets lms`
Finally, restart the lms

`make lms-restart`
And that's it, you should be able to [see](http://localhost:18000/dashboard) the theming along with the changes in the banner.