### PR TITLE
fix: update display name logic in user dropdown template

### DIFF
--- a/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-aws-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-aws-theme/lms/templates/header/user_dropdown.html
@@ -22,7 +22,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
@@ -116,23 +116,65 @@ from common.djangoapps.student.models import CourseEnrollment
   % endif
 </%block>
 
+
+<style>
+  div .alert-wrapper {
+    position: relative !important;
+  }
+
+  .banner-message {
+    line-height: 20px;
+  }
+
+  .banner-custom-close-btn {
+    position: absolute;
+    top: 1px;
+    right: -12px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    box-shadow: none !important;
+    color: #d9534f;
+  }
+
+  .banner-custom-close-btn:hover {
+    background: transparent !important;
+  }
+
+  .banner-message {
+    text-align: center;
+  }
+</style>
+
 <div class="dashboard-notifications" tabindex="-1">
   %if maintenance_banner_text:
     <div class="page-banner">
-        <div class="user-messages" role="complementary" aria-label="messages">
-            <ul class="user-messages-ul">
-                    <li>
-                        <div class="alert alert-warning" role="alert">
-                            <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
-                            <p class="lh-lg">
-                                ${sanitize_html(maintenance_banner_text) | n, decode.utf8}
-                            </p>
-                        </div>
-                    </li>
-            </ul>
-        </div>
+      <div class="user-messages" role="complementary" aria-label="messages">
+          <ul class="user-messages-ul">
+              <li>
+                <div class="alert alert-warning alert-wrapper" role="alert">
+                  <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
+                  <p class="lh-lg banner-message">
+                      ${sanitize_html(maintenance_banner_text) | n, decode.utf8}
+                  </p>
+                  <button class="banner-custom-close-btn">&times;</button>
+                </div>
+              </li>
+          </ul>
+      </div>
+    
+      <script>
+        document.addEventListener("DOMContentLoaded", () => {
+          const button = document.querySelector(".banner-custom-close-btn")
+          button?.addEventListener("click", function () {
+            this.parentElement.remove();
+          });
+        });
+      </script>
     </div>
     %endif
+
     %if banner_account_activation_message:
         <div class="dashboard-banner">
             ${banner_account_activation_message | n, decode.utf8}

--- a/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.


### PR DESCRIPTION
# Description  

This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Fixed an issue where the header displayed `nofullname` when the authenticated user's `name` existed but contained that value.  

### How to test  
1. Use a test user whose `user.profile.name` field is set. The header should display that name.  
2. Use another test user with no value set for `user.profile.name` or with `"nofullname"`. The header should now display the `username` instead.  
3. Verify that removing the `user.profile.name` value also results in the `username` being displayed.  
