### PR TITLE
fix: update display name logic in user dropdown template

### DIFF
--- a/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-amazon-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-aws-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-aws-theme/lms/templates/header/user_dropdown.html
@@ -22,7 +22,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-certiport-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-studio-theme/cms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
@@ -21,7 +21,7 @@ self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
 resume_block = retrieve_last_sitewide_block_completed(self.real_user)
-displayname = user.profile.name if hasattr(user, 'profile') and hasattr(user.profile, 'name') and user.profile.name else (self.real_user.first_name + ' ' + self.real_user.last_name) if self.real_user.first_name and self.real_user.last_name else get_enterprise_learner_generic_name(request) or username
+displayname = user.profile.name if getattr(user, 'profile', None) and getattr(user.profile, 'name', None) and user.profile.name != 'nofullname' else get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.


### PR DESCRIPTION
# Description  

This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Fixed an issue where the header displayed `nofullname` when the authenticated user's `name` existed but contained that value.  

### How to test  
1. Use a test user whose `user.profile.name` field is set. The header should display that name.  
2. Use another test user with no value set for `user.profile.name` or with `"nofullname"`. The header should now display the `username` instead.  
3. Verify that removing the `user.profile.name` value also results in the `username` being displayed.  
