### PR TITLE
feat: custom dropdown options by user role in vue theme

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/header/custom_options.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/custom_options.html
@@ -1,0 +1,80 @@
+<%
+import jwt
+
+header_payload = request.COOKIES.get('edx-jwt-cookie-header-payload')
+signature = request.COOKIES.get('edx-jwt-cookie-signature')
+
+DEFAULT_ROLES = []
+
+CERTPREP_MANAGER = {'url': '/certprep-manager', 'label': 'CertPREP Manager'}
+INSTRUCTOR_PORTAL = {'url': '/instructor-portal', 'label': 'Instructor Portal'}
+
+ROLES_PERMISSIONS = {
+    'admin': [CERTPREP_MANAGER, INSTRUCTOR_PORTAL],
+    'global_staff': [CERTPREP_MANAGER, INSTRUCTOR_PORTAL],
+    'institution_admin': [CERTPREP_MANAGER, INSTRUCTOR_PORTAL],
+    'institution_instructor': [INSTRUCTOR_PORTAL]
+}
+
+ROLES_PRIORITY = [
+    'admin',
+    'global_staff',
+    'institution_admin',
+    'institution_instructor'
+]
+
+if header_payload and signature:
+    try:
+        full_jwt = f"{header_payload}.{signature}"
+        decoded = jwt.decode(full_jwt, options={"verify_signature": False})
+        roles = decoded.get('roles', DEFAULT_ROLES)
+    except Exception:
+        roles = DEFAULT_ROLES
+else:
+    roles = DEFAULT_ROLES
+
+def get_user_links(user_roles):
+    """
+    Returns the links associated with the user's highest priority role.
+
+    Evaluates the provided roles and selects the one with the highest priority 
+    based on the ROLES_PRIORITY list. If the user has no valid roles, an empty 
+    list is returned.
+
+    Args:
+        user_roles (str | list[str]): A single role or a list of user roles.
+
+    Returns:
+        list[dict]: A list of link dictionaries (each with 'url' and 'text') 
+                    corresponding to the highest priority role.
+    """
+    if isinstance(user_roles, str):
+        user_roles = [user_roles]
+    if not user_roles:
+        return DEFAULT_ROLES
+
+    valid_roles = [role for role in user_roles if role in ROLES_PRIORITY]
+    if not valid_roles:
+        return DEFAULT_ROLES
+
+    sorted_roles = sorted(valid_roles, key=lambda r: ROLES_PRIORITY.index(r))
+    highest_role = sorted_roles[0]
+
+    return ROLES_PERMISSIONS.get(highest_role, [])
+
+hardcoded_cookie_example = {
+    'roles': ['admin']
+}
+
+menu_items = get_user_links(hardcoded_cookie_example['roles'])
+
+%>
+
+
+% for item in menu_items:
+<div class="mobile-nav-item dropdown-item dropdown-nav-item">
+    <a href="${item['url']}" role="menuitem">
+        ${item['label']}
+    </a>
+</div>
+% endfor

--- a/edx-platform/pearson-vue-theme/lms/templates/header/custom_options.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/custom_options.html
@@ -1,33 +1,44 @@
 <%
 import jwt
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 header_payload = request.COOKIES.get('edx-jwt-cookie-header-payload')
 signature = request.COOKIES.get('edx-jwt-cookie-signature')
 
+institution_path = configuration_helpers.get_value('INSTITUTION_PORTAL_PATH', '/admin')
+instructor_path = configuration_helpers.get_value('INSTRUCTOR_PORTAL_PATH', '/instructor')
+
 DEFAULT_ROLES = []
 
-CERTPREP_MANAGER = {'url': '/certprep-manager', 'label': 'CertPREP Manager'}
-INSTRUCTOR_PORTAL = {'url': '/instructor-portal', 'label': 'Instructor Portal'}
+CERTPREP_MANAGER = {'url': institution_path, 'label': 'Skilling Administrator'}
+INSTRUCTOR_PORTAL = {'url': instructor_path, 'label': 'Instructor Portal'}
 
-ROLES_PERMISSIONS = {
-    'admin': [CERTPREP_MANAGER, INSTRUCTOR_PORTAL],
-    'global_staff': [CERTPREP_MANAGER, INSTRUCTOR_PORTAL],
-    'institution_admin': [CERTPREP_MANAGER, INSTRUCTOR_PORTAL],
-    'institution_instructor': [INSTRUCTOR_PORTAL]
-}
+GLOBAL_STAFF = 'GLOBAL_STAFF'
+INSTITUTION_ADMIN = 'INSTITUTION_ADMIN'
+INSTRUCTOR = 'INSTRUCTOR'
 
 ROLES_PRIORITY = [
-    'admin',
-    'global_staff',
-    'institution_admin',
-    'institution_instructor'
+    GLOBAL_STAFF,
+    INSTITUTION_ADMIN,
+    INSTRUCTOR
 ]
+
+DEFAULT_ROLE_PERMISSIONS = {
+    GLOBAL_STAFF: [CERTPREP_MANAGER],
+    INSTITUTION_ADMIN: [CERTPREP_MANAGER],
+    INSTRUCTOR: [INSTRUCTOR_PORTAL]
+}
+
+roles = DEFAULT_ROLES
+jwt_valid = False
 
 if header_payload and signature:
     try:
         full_jwt = f"{header_payload}.{signature}"
         decoded = jwt.decode(full_jwt, options={"verify_signature": False})
-        roles = decoded.get('roles', DEFAULT_ROLES)
+        extra_data = decoded.get('extra_data', {})
+        roles = extra_data.get('permission_roles', DEFAULT_ROLES)
+        jwt_valid = True
     except Exception:
         roles = DEFAULT_ROLES
 else:
@@ -60,21 +71,31 @@ def get_user_links(user_roles):
     sorted_roles = sorted(valid_roles, key=lambda r: ROLES_PRIORITY.index(r))
     highest_role = sorted_roles[0]
 
-    return ROLES_PERMISSIONS.get(highest_role, [])
+    # Check if the role has 'INSTRUCTOR' access based on the user's roles
+    if INSTRUCTOR in user_roles and highest_role in [GLOBAL_STAFF, INSTITUTION_ADMIN]:
+        return DEFAULT_ROLE_PERMISSIONS.get(highest_role, []) + [INSTRUCTOR_PORTAL]
 
-hardcoded_cookie_example = {
-    'roles': ['admin']
-}
+    return DEFAULT_ROLE_PERMISSIONS.get(highest_role, [])
 
-menu_items = get_user_links(hardcoded_cookie_example['roles'])
+menu_items = get_user_links(roles)
 
+# This script handles edx jwt (header, signature) cookie renewal. When cookies expire,
+# valid users may lose access to their role-based menu items. By redirecting
+# to the login page while the user still has an active session, the system
+# automatically regenerates the cookie and returns the user to
+# the dashboard with proper permissions restored instead to ask again for
+# their credentials.
 %>
-
-
-% for item in menu_items:
-<div class="mobile-nav-item dropdown-item dropdown-nav-item">
-    <a href="${item['url']}" role="menuitem">
-        ${item['label']}
-    </a>
-</div>
-% endfor
+% if not jwt_valid:
+    <script type="text/javascript">
+        window.location.href = '/login';
+    </script>
+% else:
+    % for item in menu_items:
+    <div class="mobile-nav-item dropdown-item dropdown-nav-item">
+        <a href="${item['url']}" role="menuitem">
+            ${item['label']}
+        </a>
+    </div>
+    % endfor
+% endif

--- a/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
@@ -13,6 +13,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
 from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <%
@@ -26,6 +27,7 @@ enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
 should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+enable_custom_options = configuration_helpers.get_value('ENABLE_DROPDOWN_CUSTOM_OPTIONS', False)
 %>
 
 <div class="nav-item hidden-mobile">
@@ -51,6 +53,11 @@ should_show_order_history = should_redirect_to_order_history_microfrontend() and
 
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        
+        % if enable_custom_options:
+            <%include file="custom_options.html" />
+        % endif
+
         % if should_show_order_history:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
         % endif


### PR DESCRIPTION
# Description

In this PR is added a conditional logic using the values provided by `edx-jwt-cookie-header-payload` cookie, according the user role extra options in the dropdown will be shown:

```python
ROLES_PERMISSIONS = {
    'GLOBAL_STAFF': [CERTPREP_MANAGER],
    'INSTITUTION_ADMIN': [CERTPREP_MANAGER],
    'INSTRUCTOR': [INSTRUCTOR_PORTAL]
}
``` 

This PR resolves [PADV-PADV-1909](https://agile-jira.pearson.com/browse/PADV-1909)


### Visual results
![f](https://github.com/user-attachments/assets/6a39fa40-ecf0-4f2d-ac03-1463f9445a56)
_If the user is GLOBAL_STAFF also have the role INSTRUCTOR_


### How to test
1. Set in your site configurations this config `ENABLE_DROPDOWN_CUSTOM_OPTIONS` in `true`.
2. Use a user with any of these roles: `INSTRUCTOR`, `INSTITUTION_ADMIN` or `GLOBAL_STAFF` depending of the role, the options will shown, if your user does not have any of the previous roles no extra options will be rendered. 





