### PR TITLE
feat: dismissable banner using custom cookie

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/static/js/dashboard/dismiss-banner.js
+++ b/edx-platform/pearson-vue-theme/lms/static/js/dashboard/dismiss-banner.js
@@ -1,0 +1,146 @@
+/**
+ * Asynchronously hashes a given message using the SHA-1 algorithm.
+ *
+ * @param {string} message - The input string to be hashed.
+ * @returns {Promise<string|null>} A promise that resolves to the SHA-1 hash as a hexadecimal string,
+ * or null if the hashing fails or the browser does not support the required APIs.
+ *
+ * Notes:
+ * - Uses the Web Crypto API (`window.crypto.subtle`) for secure hashing.
+ * - Requires `TextEncoder` to convert the string to a Uint8Array.
+ * - If either API is unavailable, logs a warning and returns null.
+ * - In case of any runtime error, logs the error and returns null.
+ */
+async function hashMessage(message) {
+  try {
+    if (!window.crypto) {
+      console.warn('Crypto API not supported in this browser.');
+      return null;
+    }
+
+    if (!window.crypto.subtle) {
+      console.warn('SubtleCrypto not supported in this browser.');
+      return null;
+    }
+
+    if (typeof TextEncoder === 'undefined') {
+      console.warn('TextEncoder not supported in this browser.');
+      return null;
+    }
+
+    const encoder = new TextEncoder();
+    const data = encoder.encode(message);
+    const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  } catch (e) {
+    console.error('Failed to hash message:', e);
+    return null;
+  }
+}
+
+/**
+ * Retrieves the value of a cookie by name.
+ *
+ * @param {string} name - The name of the cookie to retrieve.
+ * @returns {string|null} The decoded cookie value, or null if not found or input is invalid.
+ */
+function getCookie(name) {
+  if (typeof name !== 'string' || !name) {
+    console.warn('getCookie: Invalid cookie name.');
+    return null;
+  }
+
+  try {
+    const pattern = new RegExp(
+      '(?:^|;\\s*)' +
+        encodeURIComponent('banner-message-' + name).replace(
+          /[-.+*]/g,
+          '\\$&'
+        ) +
+        '=([^;]*)'
+    );
+    const match = document.cookie.match(pattern);
+
+    if (!match) {
+      return null;
+    }
+
+    return decodeURIComponent(match[1]);
+  } catch (e) {
+    console.error('getCookie: Failed to read cookie:', e);
+    return null;
+  }
+}
+
+/**
+ * Sets a cookie with the given name, value, and expiration (in days).
+ *
+ * @param {string} name - The name of the cookie.
+ * @param {string} value - The value to store in the cookie.
+ * @param {number} [days=182] - Optional. Number of days until the cookie expires. Defaults to 182.
+ *
+ * Notes:
+ * - The cookie is set with the path `/` to make it accessible across the entire site.
+ * - The name and value are URI-encoded to ensure compatibility.
+ * - The expiration date is converted to UTC format.
+ */
+function setBannerCookie(name, value, days = 182) {
+  const expiryDate = new Date(Date.now() + days * 864e5);
+  const expires = expiryDate.toUTCString();
+  document.cookie =
+    'banner-message-' +
+    encodeURIComponent(name) +
+    '=' +
+    encodeURIComponent(value) +
+    '; expires=' +
+    expires +
+    '; path=/;';
+}
+
+/**
+ * Handles the display logic of a custom banner based on its hashed message content.
+ *
+ * This script runs once the DOM is fully loaded. It performs the following:
+ *
+ * 1. Selects the banner element, message content, and close button from the DOM.
+ * 2. Hashes the banner message using SHA-1.
+ * 3. Checks for a cookie named with the hash value:
+ *    - If the cookie is "true", hides the banner.
+ *    - If no cookie is found, shows the banner.
+ * 4. When the close button is clicked:
+ *    - Hides the banner.
+ *    - Sets a cookie with the hashed message key and value "true" to remember the dismissal.
+ */
+document.addEventListener('DOMContentLoaded', async () => {
+  const bannerElement = document.getElementById('custom-banner');
+  const messageElement = document.getElementById('banner-message-wrapper');
+  const button = document.getElementById('banner-custom-close-btn');
+
+  if (!messageElement || !bannerElement || !button) return;
+
+  const bannerMessage = messageElement.innerHTML.trim();
+  if (!bannerMessage) return;
+
+  const hash = await hashMessage(bannerMessage);
+  if (!hash) return;
+
+  const cookieValue = getCookie(hash);
+
+  if (cookieValue === 'true') {
+    if (!bannerElement.classList.contains('hidden-element')) {
+      bannerElement.classList.add('hidden-element');
+    }
+    return;
+  }
+
+  bannerElement.classList.remove('hidden-element');
+
+  const handleClose = () => {
+    bannerElement.classList.add('hidden-element');
+    setBannerCookie(hash, 'true');
+    button.removeEventListener('click', handleClose);
+  };
+
+  button.addEventListener('click', handleClose);
+});

--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_dashboard.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_dashboard.scss
@@ -1,7 +1,41 @@
+@import 'variables';
+
 .dashboard .main-container .my-courses .course .details .wrapper-course-image {
   float: left;
   margin-right: 2.35765%;
   width: 23.23176%;
   max-height: 160px;
   overflow: hidden;
+}
+
+.hidden-element {
+  display: none;
+}
+
+div .alert-wrapper {
+  position: relative ;
+}
+
+.banner-message {
+  line-height: 20px;
+}
+
+#banner-custom-close-btn {
+  position: absolute;
+  top: 1px;
+  right: -12px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  box-shadow: none;
+  color: $red-1;
+}
+
+#banner-custom-close-btn:hover {
+  background: transparent;
+}
+
+.banner-message {
+  text-align: center;
 }

--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_variables.scss
@@ -91,6 +91,7 @@ $m-blue-d2:$primary;
 $m-blue-d3:$primary;
 $uxpl-blue-hover-active:$primary;
 $m-blue:$primary;
+$red-1: #d9534f;
 
 
 // Theme fonts

--- a/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/dashboard.html
@@ -117,21 +117,25 @@ from common.djangoapps.student.models import CourseEnrollment
 
 <div class="dashboard-notifications" tabindex="-1">
   %if maintenance_banner_text:
-    <div class="page-banner">
-        <div class="user-messages" role="complementary" aria-label="messages">
-            <ul class="user-messages-ul">
-                    <li>
-                        <div class="alert alert-warning" role="alert">
-                            <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
-                            <p class="lh-lg">
-                                ${sanitize_html(maintenance_banner_text) | n, decode.utf8}
-                            </p>
-                        </div>
-                    </li>
-            </ul>
-        </div>
+    <div class="page-banner hidden-element" id="custom-banner">
+      <div class="user-messages" role="complementary" aria-label="messages">
+          <ul class="user-messages-ul">
+              <li>
+                <div class="alert alert-warning alert-wrapper" role="alert">
+                  <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
+                  <p class="lh-lg banner-message" id="banner-message-wrapper">
+                      ${sanitize_html(maintenance_banner_text) | n, decode.utf8}
+                  </p>
+                  <button class="banner-custom-close-btn" id="banner-custom-close-btn">&times;</button>
+                </div>
+              </li>
+          </ul>
+      </div>
+    
+      <script type="text/javascript" src="${static.url('js/dashboard/dismiss-banner.js')}" defer></script>
     </div>
     %endif
+
     %if banner_account_activation_message:
         <div class="dashboard-banner">
             ${banner_account_activation_message | n, decode.utf8}


### PR DESCRIPTION
# Description
In this PR is fixed the styles for banner message and added the option to close the banner

## Change log
- Fixed `line-height` for banner message.
- Added close button for banner.

## Ticket
[PADV-2251](https://agile-jira.pearson.com/browse/PADV-2251)


## Before
### Banner
![image](https://github.com/user-attachments/assets/26dce226-9277-42c1-9797-56184351f900)

## After
### Banner
![image](https://github.com/user-attachments/assets/140464e1-0fa1-4ac5-a51a-724cb6eb3d16)

### How to test


#### Configure the `vue-theme` for the lms
Go to `devstack` folder and open the lms shell
```bash 
make lms-shell 
```
Inside of the shell, move to
```bash 
/edx/etc/
```

Then open the file `lms.yml`
```bash 
# /edx/etc/
vim lms.yml
```

Find the option `ENABLE_COMPREHENSIVE_THEMING` and set it in `true`
```bash
 ENABLE_COMPREHENSIVE_THEMING: true
``` 
Find the option `COMPREHENSIVE_THEME_DIRS` and fill it with
```shell
COMPREHENSIVE_THEME_DIRS:
- '/edx/app/edx-themes/edx-platform'
``` 
Save the file and exit from vim ( if you're using it ) do not close the terminal, it will be useful soon. After that, go to http://localhost:18000/admin/theming/sitetheme/ and configure the site `http://localhost:18000/`, fill the input `Theme dir name` with the value `pearson-vue-theme` and save.

Go back to lms terminal and run this command, this could take a few minutes to complete
```shell
cd /edx/app/edxapp/edx-platform ; paver update_assets lms
``` 

#### Configure the message to see the banner
Go to [site configurations](http://localhost:18000/admin/site_configuration/siteconfiguration) and fin the site `localhost:18000`, then configure the variable `MAINTENANCE_BANNER_TEXT`:

```javascript
...
// Other site configs
  "ENABLE_DASHBOARD_SEARCH": true,
    "ECOMMERCE_PUBLIC_URL_ROOT": "http://ecommerce.main.localhost:18130",
    "LMS_ROOT_URL": "http://localhost:18000",
   // === Here ===
    "MAINTENANCE_BANNER_TEXT": "Here goes your message",
// Other site configs
    "MFE_CONFIG": {
        "IMAGE_DASHBOARD_INSTRUCTORS_URL": "https://pearson-production-media.s3.amazonaws.com/Instructor+Image.png",
        "INSTITUTION_PORTAL_PATH": "/institution-portal",
        "LMS_BASE_URL": "http://localhost:18000",
...
``` 


Finally, restart the lms
```shell
make lms-restart
``` 

And that's it, you should be able to [see](http://localhost:18000/dashboard) the theming along with the changes in the banner.
 Disable the banner and make sure it preserve the close state.


## Ticket
[PADV-2251](https://agile-jira.pearson.com/browse/PADV-2251)
