### PR TITLE
feat: Conditional Login Button Display on Coupon Pages

### DIFF
--- a/ecommerce/aws/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/aws/templates/edx/partials/_base_navbar.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+{% load static %}
+
+<header class="navbar navbar-default">
+  <div class="container">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+      <button id="hamburger-button" class="navbar-toggle collapsed" data-toggle="collapse"
+              data-target="#main-navbar-collapse" type="button" aria-expanded="false">
+        <span class="sr-only">{% trans "Toggle navigation" as tmsg %}{{ tmsg | force_escape }}</span>
+        <span aria-hidden="true" class="icon-bar"></span>
+        <span aria-hidden="true" class="icon-bar"></span>
+        <span aria-hidden="true" class="icon-bar"></span>
+      </button>
+      {% block navbar_brand %}{% endblock navbar_brand %}
+    </div>
+
+    <div class="collapse navbar-collapse" id="main-navbar-collapse">
+      <ul class="nav navbar-nav navbar-right">
+        {% if user.is_authenticated %}
+          <li class="btn-group user-menu">
+            <button data-hj-suppress type="button" class="btn btn-default hidden-xs main-btn nav-button"
+                    onclick="window.open('{{ lms_dashboard_url }}');">
+              <i class="icon fa fa-home" aria-hidden="true"></i>
+              <span class="sr-only">{% trans "Dashboard for:" as tmsg %}{{ tmsg | force_escape }}</span>
+              {{ user.username }}
+            </button>
+            <button type="button" class="btn btn-default dropdown-toggle hidden-xs nav-button"
+                    data-toggle="dropdown"
+                    aria-haspopup="true">
+              <span class="caret"></span>
+              <span class="sr-only">{% trans "Toggle Dropdown" as tmsg %}{{ tmsg | force_escape }}</span>
+            </button>
+            <ul class="dropdown-menu" aria-expanded="false">
+              {% block dropdown_menu %}{% endblock dropdown_menu %}
+            </ul>
+              {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
+          </li>
+        {% else %}
+          <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
+          <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
+          </a>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</header>

--- a/ecommerce/aws/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/aws/templates/edx/partials/_base_navbar.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 {% load static %}
+{% load core_extras %}
+{% settings_value 'custom_settings' as custom_settings %}
 
 <header class="navbar navbar-default">
   <div class="container">
@@ -37,9 +39,13 @@
               {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
           </li>
         {% else %}
-          <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
-          <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
-          </a>
+          {# Show login button except when: #}
+          {# ALL conditions are met: COUPONS_DISABLE_LOGIN_BUTTON: true + valid request + path contains "/coupons/offer/" #}
+          {# Otherwise, show the button (missing request, missing path, different URL, or COUPONS_DISABLE_LOGIN_BUTTON: false or not defined) #}
+          {% if not custom_settings.COUPONS_DISABLE_LOGIN_BUTTON|default_if_none:False or not request or not request.path or not "/coupons/offer/" in request.path|default_if_none:"" %}
+            <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
+            <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
+          {% endif %}
         {% endif %}
       </ul>
     </div>

--- a/ecommerce/certprep/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/certprep/templates/edx/partials/_base_navbar.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+{% load static %}
+
+<header class="navbar navbar-default">
+  <div class="container">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+      <button id="hamburger-button" class="navbar-toggle collapsed" data-toggle="collapse"
+              data-target="#main-navbar-collapse" type="button" aria-expanded="false">
+        <span class="sr-only">{% trans "Toggle navigation" as tmsg %}{{ tmsg | force_escape }}</span>
+        <span aria-hidden="true" class="icon-bar"></span>
+        <span aria-hidden="true" class="icon-bar"></span>
+        <span aria-hidden="true" class="icon-bar"></span>
+      </button>
+      {% block navbar_brand %}{% endblock navbar_brand %}
+    </div>
+
+    <div class="collapse navbar-collapse" id="main-navbar-collapse">
+      <ul class="nav navbar-nav navbar-right">
+        {% if user.is_authenticated %}
+          <li class="btn-group user-menu">
+            <button data-hj-suppress type="button" class="btn btn-default hidden-xs main-btn nav-button"
+                    onclick="window.open('{{ lms_dashboard_url }}');">
+              <i class="icon fa fa-home" aria-hidden="true"></i>
+              <span class="sr-only">{% trans "Dashboard for:" as tmsg %}{{ tmsg | force_escape }}</span>
+              {{ user.username }}
+            </button>
+            <button type="button" class="btn btn-default dropdown-toggle hidden-xs nav-button"
+                    data-toggle="dropdown"
+                    aria-haspopup="true">
+              <span class="caret"></span>
+              <span class="sr-only">{% trans "Toggle Dropdown" as tmsg %}{{ tmsg | force_escape }}</span>
+            </button>
+            <ul class="dropdown-menu" aria-expanded="false">
+              {% block dropdown_menu %}{% endblock dropdown_menu %}
+            </ul>
+              {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
+          </li>
+        {% else %}
+          <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
+          <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
+          </a>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</header>

--- a/ecommerce/certprep/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/certprep/templates/edx/partials/_base_navbar.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 {% load static %}
+{% load core_extras %}
+{% settings_value 'custom_settings' as custom_settings %}
 
 <header class="navbar navbar-default">
   <div class="container">
@@ -37,9 +39,13 @@
               {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
           </li>
         {% else %}
-          <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
-          <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
-          </a>
+          {# Show login button except when: #}
+          {# ALL conditions are met: COUPONS_DISABLE_LOGIN_BUTTON: true + valid request + path contains "/coupons/offer/" #}
+          {# Otherwise, show the button (missing request, missing path, different URL, or COUPONS_DISABLE_LOGIN_BUTTON: false or not defined) #}
+          {% if not custom_settings.COUPONS_DISABLE_LOGIN_BUTTON|default_if_none:False or not request or not request.path or not "/coupons/offer/" in request.path|default_if_none:"" %}
+            <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
+            <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
+          {% endif %}
         {% endif %}
       </ul>
     </div>

--- a/ecommerce/pearson-theme/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/pearson-theme/templates/edx/partials/_base_navbar.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+{% load static %}
+
+<header class="navbar navbar-default">
+  <div class="container">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+      <button id="hamburger-button" class="navbar-toggle collapsed" data-toggle="collapse"
+              data-target="#main-navbar-collapse" type="button" aria-expanded="false">
+        <span class="sr-only">{% trans "Toggle navigation" as tmsg %}{{ tmsg | force_escape }}</span>
+        <span aria-hidden="true" class="icon-bar"></span>
+        <span aria-hidden="true" class="icon-bar"></span>
+        <span aria-hidden="true" class="icon-bar"></span>
+      </button>
+      {% block navbar_brand %}{% endblock navbar_brand %}
+    </div>
+
+    <div class="collapse navbar-collapse" id="main-navbar-collapse">
+      <ul class="nav navbar-nav navbar-right">
+        {% if user.is_authenticated %}
+          <li class="btn-group user-menu">
+            <button data-hj-suppress type="button" class="btn btn-default hidden-xs main-btn nav-button"
+                    onclick="window.open('{{ lms_dashboard_url }}');">
+              <i class="icon fa fa-home" aria-hidden="true"></i>
+              <span class="sr-only">{% trans "Dashboard for:" as tmsg %}{{ tmsg | force_escape }}</span>
+              {{ user.username }}
+            </button>
+            <button type="button" class="btn btn-default dropdown-toggle hidden-xs nav-button"
+                    data-toggle="dropdown"
+                    aria-haspopup="true">
+              <span class="caret"></span>
+              <span class="sr-only">{% trans "Toggle Dropdown" as tmsg %}{{ tmsg | force_escape }}</span>
+            </button>
+            <ul class="dropdown-menu" aria-expanded="false">
+              {% block dropdown_menu %}{% endblock dropdown_menu %}
+            </ul>
+              {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
+          </li>
+        {% else %}
+          <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
+          <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
+          </a>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</header>

--- a/ecommerce/pearson-theme/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/pearson-theme/templates/edx/partials/_base_navbar.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 {% load static %}
+{% load core_extras %}
+{% settings_value 'custom_settings' as custom_settings %}
 
 <header class="navbar navbar-default">
   <div class="container">
@@ -37,9 +39,13 @@
               {% block small_dropdown_menu %}{% endblock small_dropdown_menu %}
           </li>
         {% else %}
-          <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
-          <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
-          </a>
+          {# Show login button except when: #}
+          {# ALL conditions are met: COUPONS_DISABLE_LOGIN_BUTTON: true + valid request + path contains "/coupons/offer/" #}
+          {# Otherwise, show the button (missing request, missing path, different URL, or COUPONS_DISABLE_LOGIN_BUTTON: false or not defined) #}
+          {% if not custom_settings.COUPONS_DISABLE_LOGIN_BUTTON|default_if_none:False or not request or not request.path or not "/coupons/offer/" in request.path|default_if_none:"" %}
+            <a class="btn btn-primary navbar-btn hidden-xs" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a>
+            <li class="visible-xs"><a class="nav-link" href="{% url 'login' %}">{% trans "Login" as tmsg %}{{ tmsg | force_escape }}</a></li>
+          {% endif %}
         {% endif %}
       </ul>
     </div>


### PR DESCRIPTION
# Description

This PR updates the conditional logic to control the visibility of the login button in the navigation bar based on application settings and the current page path.

---

## What Changed

* Replaced previous condition with a more robust version that handles missing `request`, `path`, or query strings.
* The login button is now hidden only if **all** the following are true:
    1. The setting `COUPONS_DISABLE_LOGIN_BUTTON` is `True` (default `False`)
    2. A valid `request.path` exists
    3. The path includes `/coupons/offer/` (including query params)

---

### Condition Breakdown

* **Primary setting**: `COUPONS_DISABLE_LOGIN_BUTTON` (defaults to `False`)
* **Safety checks**:
  - Skips logic if `request` or `request.path` are missing
* **Targeted path match**: Checks for `/coupons/offer/` substring in URL
* **Operator**: Uses `OR` logic — button is shown if any of the above checks fail

---

## Business Logic

The login button will be **displayed** when:

* `COUPONS_DISABLE_LOGIN_BUTTON` is `False`, **OR**
* There is no `request` or `request.path`, **OR**
* The current path **does not** include `/coupons/offer/`

The login button will be **hidden** only when:

* `COUPONS_DISABLE_LOGIN_BUTTON` is `True`, **AND**
* There is a valid `request.path`, **AND**
* The current path **includes** `/coupons/offer/`

---

## How to Test

1. In `ecommerce/theming/helpers.py`, comment this:

    ```python
    if bool(get_current_request()) and waffle.switch_is_active(settings.DISABLE_THEMING_ON_RUNTIME_SWITCH):
        return False
    ```

2. In `ecommerce/ecommerce/settings/devstack.py`, add:

    ```python
    ENABLE_COMPREHENSIVE_THEMING = True
    COMPREHENSIVE_THEME_DIRS = ["/edx/app/edx-themes/ecommerce"]
    DEFAULT_SITE_THEME = "pearson-theme"
    ```

3. Inside the e-commerce container:

    ```shell
    cd /edx/app/ecommerce/ecommerce
    python manage.py update_assets
    ```

4. Register the theme at  
   `http://localhost:18130/admin/theming/sitetheme/`  
   Site: `localhost:18130`, Theme: `pearson-theme`

5. At  
   `http://localhost:18130/admin/core/siteconfiguration/`  
   Site: `localhost:18130`, in **Custom settings**, add:

    ```json
    {"COUPONS_DISABLE_LOGIN_BUTTON": true}
    ```

6. Restart the devserver:

    ```shell
    make dev.restart-devserver.ecommerce
    ```

> [!NOTE]  
> You must have this repo at the same level of the ecommerce folder.

---

## Test Cases

All these routes work on http://localhost:18130

| Page Path               | Global Setting | Expected Result   | Rationale                                               |
|------------------------|----------------|-------------------|----------------------------------------------------------|
| /coupons/offer/        | False          | ✅ Button shows   | Global setting allows login button                      |
| /coupons/offer/        | True           | ❌ Button hidden  | Setting is True and path matches target                 |
| /coupons/offer/?code=1 | True           | ❌ Button hidden  | Setting is True and path contains `/coupons/offer/`     |
| /coupons/offer         | True           | ❌ Button hidden  | Still matches `/coupons/offer/` without trailing slash  |
| /coupons/offer?        | True           | ❌ Button hidden  | Path still includes the substring `/coupons/offer/`     |
| /                     | True           | ✅ Button shows   | Does not match `/coupons/offer/`                        |
| /courses/             | True           | ✅ Button shows   | Irrelevant path, button should be visible               |
| /500                  | True           | ✅ Button shows   | Error path, does not match `/coupons/offer/`            |

---
