### PR TITLE
fix: input css selector for register form

### DIFF
--- a/edx-platform/pearson-amazon-theme/lms/static/sass/partials/lms/theme/_login-register.scss
+++ b/edx-platform/pearson-amazon-theme/lms/static/sass/partials/lms/theme/_login-register.scss
@@ -62,6 +62,7 @@ div.js-auth-warning.status > div.message-copy,
 input#register-name,
 input#register-email,
 input#register-company,
+input#register-username,
 input.custom-input-override {
   height: 50px;
   border: 1px solid $register-input-border-color;

--- a/edx-platform/pearson-pte-theme/lms/static/sass/partials/lms/theme/_login-register.scss
+++ b/edx-platform/pearson-pte-theme/lms/static/sass/partials/lms/theme/_login-register.scss
@@ -62,6 +62,7 @@ div.js-auth-warning.status > div.message-copy,
 input#register-name,
 input#register-email,
 input#register-company,
+input#register-username,
 input.custom-input-override {
   height: 50px;
   border: 1px solid $register-input-border-color;

--- a/edx-platform/pearson-theme/lms/static/sass/partials/lms/theme/_login-register.scss
+++ b/edx-platform/pearson-theme/lms/static/sass/partials/lms/theme/_login-register.scss
@@ -60,7 +60,9 @@ div.js-auth-warning.status > div.message-copy,
 
 /* Inputs */
 input#register-name,
+input#register-email,
 input#register-company,
+input#register-username,
 input.custom-input-override {
   height: 50px;
   border: 1px solid $register-input-border-color;

--- a/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_login-register.scss
+++ b/edx-platform/pearson-vue-theme/lms/static/sass/partials/lms/theme/_login-register.scss
@@ -60,7 +60,9 @@ div.js-auth-warning.status > div.message-copy,
 
 /* Inputs */
 input#register-name,
+input#register-email,
 input#register-company,
+input#register-username,
 input.custom-input-override {
   height: 50px;
   border: 1px solid $vue-register-input-border-color;


### PR DESCRIPTION
# Description

In this PR is fixed the css input selector for `external ID` and `userName` input  field in register page.