### PR TITLE
feat: add exam dashboard link to authenticated navbar

### DIFF
--- a/edx-platform/pearson-vue-theme/lms/templates/header/navbar-authenticated.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/navbar-authenticated.html
@@ -18,6 +18,11 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
 
+  mfe_config = configuration_helpers.get_value('MFE_CONFIG') or {}
+  
+  enable_exam_dashboard_link = mfe_config.get("ENABLE_EXAM_DASHBOARD")
+  exam_dashboard_base_url = mfe_config.get("EXAM_DASHBOARD_MFE_BASE_URL")
+
   if online_help_token == "instructor":
     help_link = doc_link
   elif support_link:
@@ -35,6 +40,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
              Pearson ${_("Courses")}
         </a>
       </div>
+	  % if enable_exam_dashboard_link and exam_dashboard_base_url:
+	    <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="tab-nav-link" href="${exam_dashboard_base_url}">
+             ${_("Exams")}
+        </a>
+      </div>
+	  % endif
       % if show_program_listing:
         <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
           <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"


### PR DESCRIPTION
This pull request updates the authenticated navbar in the Pearson Vue theme to optionally display an "Exams" navigation link based on a feature toggle. The changes introduce a new Waffle switch to control the visibility of the exam dashboard link and ensure the link is only shown when enabled and configured.

**Feature toggle integration:**

* Added import of `WaffleSwitch` from `edx_toggles.toggles` to support feature flagging in the navbar template.
* Defined a new Waffle switch `header.enable_exam_dashboard_link` and retrieved the exam dashboard base URL from site configuration.

**Navbar UI update:**

* Added conditional logic and markup to display an "Exams" tab in the navbar only when the Waffle switch is enabled and the base URL is configured.

### How to test?
- Have a Pearson environment
- Clone this repo in this branch to have the required changes 
- Enable `pearson-vue-theme` following [this guide](https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/configuration/changing_appearance/theming/enable_themes.html)
- Compile the theme following [this guide](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-palm.master/configuration/changing_appearance/theming/compiling_theme.html#compiling-a-theme)
- Enable a new switch `header.enable_exam_dashboard_link`
- Create the settings `"EXAM_DASHBOARD_MFE_BASE_URL": "http://localhost:2005"` to your `Site Configuration`
- You should see the `Exams` menu in the header navbar

### Screenshots
<img width="1639" height="733" alt="image" src="https://github.com/user-attachments/assets/d8b1739c-bb50-406e-8d29-a40f1fa80169" />
