### PR TITLE
fix: solve the loop error in register sign in view

### DIFF
--- a/edx-platform/pearson-pte-theme/lms/static/js/student_account/register-swap-error-position.js
+++ b/edx-platform/pearson-pte-theme/lms/static/js/student_account/register-swap-error-position.js
@@ -62,13 +62,27 @@ function initMessageCopyObserver() {
     return false;
   }
 
+  var isProcessing = false;
   var observer = new MutationObserver(function() {
-    checkAndProcess();
+    if (isProcessing) {
+      return;
+    }
+
+    isProcessing = true;
+    observer.disconnect();
+
+    try {
+      checkAndProcess();
+    } finally {
+      observer.observe(document.body, { childList: true, subtree: true });
+      isProcessing = false;
+    }
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
-
+  // First pass before observing, to avoid reacting to our own initial DOM changes.
   checkAndProcess();
+
+  observer.observe(document.body, { childList: true, subtree: true });
 }
 
 $(document).ready(function() {

--- a/edx-platform/pearson-theme/lms/static/js/student_account/register-swap-error-position.js
+++ b/edx-platform/pearson-theme/lms/static/js/student_account/register-swap-error-position.js
@@ -62,13 +62,27 @@ function initMessageCopyObserver() {
     return false;
   }
 
+  var isProcessing = false;
   var observer = new MutationObserver(function() {
-    checkAndProcess();
+    if (isProcessing) {
+      return;
+    }
+
+    isProcessing = true;
+    observer.disconnect();
+
+    try {
+      checkAndProcess();
+    } finally {
+      observer.observe(document.body, { childList: true, subtree: true });
+      isProcessing = false;
+    }
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
-
+  // First pass before observing, to avoid reacting to our own initial DOM changes.
   checkAndProcess();
+
+  observer.observe(document.body, { childList: true, subtree: true });
 }
 
 $(document).ready(function() {

--- a/edx-platform/pearson-vue-theme/lms/static/js/student_account/register-swap-error-position.js
+++ b/edx-platform/pearson-vue-theme/lms/static/js/student_account/register-swap-error-position.js
@@ -62,13 +62,27 @@ function initMessageCopyObserver() {
     return false;
   }
 
+  var isProcessing = false;
   var observer = new MutationObserver(function() {
-    checkAndProcess();
+    if (isProcessing) {
+      return;
+    }
+
+    isProcessing = true;
+    observer.disconnect();
+
+    try {
+      checkAndProcess();
+    } finally {
+      observer.observe(document.body, { childList: true, subtree: true });
+      isProcessing = false;
+    }
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
-
+  // First pass before observing, to avoid reacting to our own initial DOM changes.
   checkAndProcess();
+
+  observer.observe(document.body, { childList: true, subtree: true });
 }
 
 $(document).ready(function() {

--- a/edx-platform/pearson-vue-theme/lms/templates/header/header.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/header.html
@@ -91,7 +91,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % if user.is_authenticated:
                 <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
             % else:
-                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
             % endif
             <label><span class="sr">${_("Choose Language")}</span>
             <select class="input select language-selector" id="settings-language-value" name="language">


### PR DESCRIPTION
## Description

This PR solve the issue when a user login from IES and is redirected to `{lms-base}/register` to complete the register. The problem was that the workflow in the `register-swap-error-position.js` file force a loop that can not solve the error message to update the register form.

## Changes

- pearson-pte-theme `register-swap-error-position.js`
- pearson-theme `register-swap-error-position.js`
- pearson-vue-theme `register-swap-error-position.js` and `header.html`

## How to test

1. Set a tutor Ulmo environment using the `pearson/ulmo` branches
2. Add the openedx-themes repository to the `COMPREHENSIVE_THEME_DIRS_PATHS`
3. Build and launch the environment
4. Follow the steps in this [PR](https://github.com/Pearson-Advance/edx-platform/pull/168) to run a SAML test
5. Login from SAML test
6. See the http://local.openedx.io:8000/register URL redirection and check something like:

<img width="1867" height="959" alt="Screenshot 2026-04-14 at 03 15 45" src="https://github.com/user-attachments/assets/0e579940-969a-49b3-9e3c-e099d40b3269" />

The answer must be immediately!