### PR TITLE
PADV-3326 fix: header configurations

### DIFF
--- a/edx-platform/pearson-pte-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-pte-theme/lms/templates/header/user_dropdown.html
@@ -31,8 +31,17 @@ enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
 
-profile_url = "{}{}".format(settings.PROFILE_MICROFRONTEND_URL, username)
-account_settings_url = getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "")
+profile_mfe_url = configuration_helpers.get_value(
+    'PROFILE_MICROFRONTEND_URL',
+    getattr(settings, "PROFILE_MICROFRONTEND_URL", ""),
+)
+
+profile_url = "{}{}".format(profile_mfe_url, username)
+
+account_settings_url = configuration_helpers.get_value(
+    'ACCOUNT_MICROFRONTEND_URL',
+    getattr(settings, "ACCOUNT_MICROFRONTEND_URL", ""),
+)
 
 order_history_url = (
     getattr(settings, "ORDER_HISTORY_MICROFRONTEND_URL", "")

--- a/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-theme/lms/templates/header/user_dropdown.html
@@ -27,22 +27,34 @@ displayname = (
     or username
 )
 enterprise_customer_portal = get_enterprise_learner_portal(request)
+
+# Read values from Site Configuration first, fallback to Django settings
+profile_mfe_url = configuration_helpers.get_value(
+    'PROFILE_MICROFRONTEND_URL',
+    getattr(settings, 'PROFILE_MICROFRONTEND_URL', None),
+)
+
+account_mfe_url = configuration_helpers.get_value(
+    'ACCOUNT_MICROFRONTEND_URL',
+    getattr(settings, 'ACCOUNT_MICROFRONTEND_URL', None),
+)
+
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
 should_show_order_history = bool(getattr(settings, 'ORDER_HISTORY_MICROFRONTEND_URL', None)) and not enterprise_customer_portal
 profile_url = None
-if getattr(settings, 'PROFILE_MICROFRONTEND_URL', None):
-    # Asegura que el base termine en /
-    base = settings.PROFILE_MICROFRONTEND_URL.rstrip('/') + '/'
+if profile_mfe_url:
+    base = profile_mfe_url.rstrip('/') + '/'
     profile_url = urljoin(base, f'{username}')
 else:
     try:
         profile_url = reverse('learner_profile', kwargs={'username': username})
     except NoReverseMatch:
         profile_url = reverse('dashboard')
+
 account_url = None
-if getattr(settings, 'ACCOUNT_MICROFRONTEND_URL', None):
-    account_url = settings.ACCOUNT_MICROFRONTEND_URL
+if account_mfe_url:
+    account_url = account_mfe_url
 else:
     try:
         account_url = reverse('account_settings')

--- a/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
+++ b/edx-platform/pearson-vue-theme/lms/templates/header/user_dropdown.html
@@ -34,8 +34,17 @@ enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## not apply to the learner's method of purchasing content.
 enable_custom_options = configuration_helpers.get_value('ENABLE_DROPDOWN_CUSTOM_OPTIONS', False)
 
-profile_url = "{}{}".format(settings.PROFILE_MICROFRONTEND_URL, username)
-account_settings_url = getattr(settings, "ACCOUNT_MICROFRONTEND_URL", "")
+profile_mfe_url = configuration_helpers.get_value(
+    'PROFILE_MICROFRONTEND_URL',
+    getattr(settings, "PROFILE_MICROFRONTEND_URL", ""),
+)
+
+profile_url = "{}{}".format(profile_mfe_url, username)
+
+account_settings_url = configuration_helpers.get_value(
+    'ACCOUNT_MICROFRONTEND_URL',
+    getattr(settings, "ACCOUNT_MICROFRONTEND_URL", ""),
+)
 
 order_history_url = (
     getattr(settings, "ORDER_HISTORY_MICROFRONTEND_URL", "")


### PR DESCRIPTION
### Ticket
https://pearson.atlassian.net/browse/PADV-3326

### Description
Fix error in header configurations because only takes values from django, so read values from Site Configuration first, fallback to Django 

### How to test
Using tutor, copy the pearson-vue-theme folder to env/build/openedx/themes/openedx-vue-themes
Build the image with tutor image build openedx-dev if you're using tutor dev, otherwise tutor image build openedx for tutor local
After the building process, run tutor dev launch
Run tutor dev do settheme pearson-vue-theme
Verify the theme changes: